### PR TITLE
[#22] ktlint 옵션 최적화 및 수정

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,6 +20,10 @@ ktlint_standard_argument-list-wrapping = disabled
 ktlint_standard_no-wildcard-imports = disabled
 ktlint_standard_parameter-list-wrapping = disabled
 ktlint_standard_spacing-between-declarations-with-annotations = disabled
+ktlint_standard_annotation = disabled
+ktlint_standard_class-signature = disabled
+ktlint_standard_function-signature = disabled
+ktlint_standard_chain-method-continuation = disabled
 
 # 함수 네이밍을 Camel Case로 강제하지 않는다. (ex. Composable 함수)
 ktlint_standard_function-naming = disabled

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -32,7 +32,7 @@ android {
             isMinifyEnabled = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
-                "proguard-rules.pro"
+                "proguard-rules.pro",
             )
             signingConfig = signingConfigs.getByName("release")
         }

--- a/core/designsystem/src/main/java/com/chac/core/designsystem/ui/theme/Theme.kt
+++ b/core/designsystem/src/main/java/com/chac/core/designsystem/ui/theme/Theme.kt
@@ -22,15 +22,15 @@ private val LightColorScheme =
         primary = Purple40,
         secondary = PurpleGrey40,
         tertiary = Pink40,
-    /* Other default colors to override
-    background = Color(0xFFFFFBFE),
-    surface = Color(0xFFFFFBFE),
-    onPrimary = Color.White,
-    onSecondary = Color.White,
-    onTertiary = Color.White,
-    onBackground = Color(0xFF1C1B1F),
-    onSurface = Color(0xFF1C1B1F),
-     */
+        /* Other default colors to override
+        background = Color(0xFFFFFBFE),
+        surface = Color(0xFFFFFBFE),
+        onPrimary = Color.White,
+        onSecondary = Color.White,
+        onTertiary = Color.White,
+        onBackground = Color(0xFF1C1B1F),
+        onSurface = Color(0xFF1C1B1F),
+         */
     )
 
 @Composable
@@ -40,16 +40,15 @@ fun ChacTheme(
     dynamicColor: Boolean = true,
     content: @Composable () -> Unit,
 ) {
-    val colorScheme =
-        when {
-            dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-                val context = LocalContext.current
-                if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-            }
-
-            darkTheme -> DarkColorScheme
-            else -> LightColorScheme
+    val colorScheme = when {
+        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            val context = LocalContext.current
+            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
         }
+
+        darkTheme -> DarkColorScheme
+        else -> LightColorScheme
+    }
 
     MaterialTheme(
         colorScheme = colorScheme,

--- a/core/designsystem/src/main/java/com/chac/core/designsystem/ui/theme/Type.kt
+++ b/core/designsystem/src/main/java/com/chac/core/designsystem/ui/theme/Type.kt
@@ -17,20 +17,20 @@ val Typography =
                 lineHeight = 24.sp,
                 letterSpacing = 0.5.sp,
             ),
-    /* Other default text styles to override
-    titleLarge = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Normal,
-        fontSize = 22.sp,
-        lineHeight = 28.sp,
-        letterSpacing = 0.sp
-    ),
-    labelSmall = TextStyle(
-        fontFamily = FontFamily.Default,
-        fontWeight = FontWeight.Medium,
-        fontSize = 11.sp,
-        lineHeight = 16.sp,
-        letterSpacing = 0.5.sp
-    )
-     */
+        /* Other default text styles to override
+        titleLarge = TextStyle(
+            fontFamily = FontFamily.Default,
+            fontWeight = FontWeight.Normal,
+            fontSize = 22.sp,
+            lineHeight = 28.sp,
+            letterSpacing = 0.sp
+        ),
+        labelSmall = TextStyle(
+            fontFamily = FontFamily.Default,
+            fontWeight = FontWeight.Medium,
+            fontSize = 11.sp,
+            lineHeight = 16.sp,
+            letterSpacing = 0.5.sp
+        )
+         */
     )

--- a/core/permission/src/main/java/com/chac/core/permission/MediaWithLocationPermissionUseCase.kt
+++ b/core/permission/src/main/java/com/chac/core/permission/MediaWithLocationPermissionUseCase.kt
@@ -4,13 +4,11 @@ import android.content.Context
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
-class MediaWithLocationPermissionUseCase
-    @Inject
-    constructor(
-        @ApplicationContext private val context: Context,
-    ) {
-        fun hasFullPermission(): Boolean = MediaWithLocationPermissionUtil.hasFullAccessPermission(context)
+class MediaWithLocationPermissionUseCase @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    fun hasFullPermission(): Boolean = MediaWithLocationPermissionUtil.hasFullAccessPermission(context)
 
-        fun needsPermissionRequest(): Boolean =
-            !MediaWithLocationPermissionUtil.hasOnlyPartialAccessPhotosVideosPermission(context) && !hasFullPermission()
-    }
+    fun needsPermissionRequest(): Boolean =
+        !MediaWithLocationPermissionUtil.hasOnlyPartialAccessPhotosVideosPermission(context) && !hasFullPermission()
+}

--- a/core/permission/src/main/java/com/chac/core/permission/MediaWithLocationPermissionUtil.kt
+++ b/core/permission/src/main/java/com/chac/core/permission/MediaWithLocationPermissionUtil.kt
@@ -32,13 +32,12 @@ object MediaWithLocationPermissionUtil : PermissionUtil() {
         launch()
     }
 
-    fun checkPermission(context: Context): Boolean =
-        permissions.all { permission ->
-            ContextCompat.checkSelfPermission(
-                context,
-                permission,
-            ) == PackageManager.PERMISSION_GRANTED
-        }
+    fun checkPermission(context: Context): Boolean = permissions.all { permission ->
+        ContextCompat.checkSelfPermission(
+            context,
+            permission,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
 
     fun hasFullAccessPermission(context: Context): Boolean =
         hasFullAccessPhotosVideosPermission(context) && hasMediaAccessPermission(context)
@@ -59,57 +58,51 @@ object MediaWithLocationPermissionUtil : PermissionUtil() {
         }
 
     @RequiresApi(Build.VERSION_CODES.UPSIDE_DOWN_CAKE)
-    private fun hasReadMediaVisualUserSelectedPermission(context: Context): Boolean =
-        ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED,
-        ) == PackageManager.PERMISSION_GRANTED
+    private fun hasReadMediaVisualUserSelectedPermission(context: Context): Boolean = ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.READ_MEDIA_VISUAL_USER_SELECTED,
+    ) == PackageManager.PERMISSION_GRANTED
 
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-    private fun hasReadMediaImagesPermission(context: Context): Boolean =
-        ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.READ_MEDIA_IMAGES,
-        ) == PackageManager.PERMISSION_GRANTED
+    private fun hasReadMediaImagesPermission(context: Context): Boolean = ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.READ_MEDIA_IMAGES,
+    ) == PackageManager.PERMISSION_GRANTED
 
     @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-    private fun hasReadMediaVideoPermission(context: Context): Boolean =
-        ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.READ_MEDIA_VIDEO,
-        ) == PackageManager.PERMISSION_GRANTED
+    private fun hasReadMediaVideoPermission(context: Context): Boolean = ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.READ_MEDIA_VIDEO,
+    ) == PackageManager.PERMISSION_GRANTED
 
-    private fun hasReadStoragePermission(context: Context): Boolean =
-        ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.READ_EXTERNAL_STORAGE,
-        ) == PackageManager.PERMISSION_GRANTED
+    private fun hasReadStoragePermission(context: Context): Boolean = ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.READ_EXTERNAL_STORAGE,
+    ) == PackageManager.PERMISSION_GRANTED
 
-    private fun hasMediaAccessPermission(context: Context): Boolean =
-        ContextCompat.checkSelfPermission(
-            context,
-            Manifest.permission.ACCESS_MEDIA_LOCATION,
-        ) == PackageManager.PERMISSION_GRANTED
+    private fun hasMediaAccessPermission(context: Context): Boolean = ContextCompat.checkSelfPermission(
+        context,
+        Manifest.permission.ACCESS_MEDIA_LOCATION,
+    ) == PackageManager.PERMISSION_GRANTED
 
     fun getPermissionResultListener(
         onGranted: () -> Unit,
         onDenied: (() -> Unit)?,
         onPermanentlyDenied: (() -> Unit)?,
-    ): (PermissionState) -> Unit =
-        { state ->
-            when (state) {
-                PermissionState.Granted -> onGranted()
-                PermissionState.Denied, PermissionState.PartiallyGranted -> {
-                    if (onDenied != null) {
-                        onDenied()
-                    }
+    ): (PermissionState) -> Unit = { state ->
+        when (state) {
+            PermissionState.Granted -> onGranted()
+            PermissionState.Denied, PermissionState.PartiallyGranted -> {
+                if (onDenied != null) {
+                    onDenied()
                 }
+            }
 
-                PermissionState.PermanentlyDenied -> {
-                    if (onPermanentlyDenied != null) {
-                        onPermanentlyDenied()
-                    }
+            PermissionState.PermanentlyDenied -> {
+                if (onPermanentlyDenied != null) {
+                    onPermanentlyDenied()
                 }
             }
         }
+    }
 }

--- a/core/permission/src/main/java/com/chac/core/permission/PermissionUtil.kt
+++ b/core/permission/src/main/java/com/chac/core/permission/PermissionUtil.kt
@@ -35,20 +35,18 @@ abstract class PermissionUtil {
         val deniedList: List<String> = result.filter { !it.value }.map { it.key }
         val grantedCount = result.count { it.value }
 
-        var state =
-            when {
-                deniedList.isEmpty() -> PermissionState.Granted
-                grantedCount > 0 -> PermissionState.PartiallyGranted
-                else -> PermissionState.Denied
-            }
+        var state = when {
+            deniedList.isEmpty() -> PermissionState.Granted
+            grantedCount > 0 -> PermissionState.PartiallyGranted
+            else -> PermissionState.Denied
+        }
 
         if (state == PermissionState.Denied) {
-            val permanentlyMappedList =
-                deniedList.map {
-                    activity?.let { activity ->
-                        shouldShowRequestPermissionRationale(activity, it)
-                    }
+            val permanentlyMappedList = deniedList.map {
+                activity?.let { activity ->
+                    shouldShowRequestPermissionRationale(activity, it)
                 }
+            }
 
             if (permanentlyMappedList.contains(false)) {
                 // 사용자가 [다시 묻지 않음] 을 선택한 경우 -> 영구 거부로 판단함.
@@ -63,34 +61,32 @@ abstract class PermissionUtil {
         onGranted: () -> Unit,
         onDenied: (() -> Unit)?,
         onPermanentlyDenied: (() -> Unit)?,
-    ): (PermissionState) -> Unit =
-        { state ->
-            when (state) {
-                PermissionState.PartiallyGranted,
-                PermissionState.Granted,
-                -> onGranted()
+    ): (PermissionState) -> Unit = { state ->
+        when (state) {
+            PermissionState.PartiallyGranted,
+            PermissionState.Granted,
+            -> onGranted()
 
-                PermissionState.Denied -> {
-                    if (onDenied != null) {
-                        onDenied()
-                    }
+            PermissionState.Denied -> {
+                if (onDenied != null) {
+                    onDenied()
                 }
+            }
 
-                PermissionState.PermanentlyDenied -> {
-                    if (onPermanentlyDenied != null) {
-                        onPermanentlyDenied()
-                    }
+            PermissionState.PermanentlyDenied -> {
+                if (onPermanentlyDenied != null) {
+                    onPermanentlyDenied()
                 }
             }
         }
+    }
 
-    fun checkPermissionGranted(context: Context): Boolean =
-        permissions.all { permission ->
-            ContextCompat.checkSelfPermission(
-                context,
-                permission,
-            ) == PackageManager.PERMISSION_GRANTED
-        }
+    fun checkPermissionGranted(context: Context): Boolean = permissions.all { permission ->
+        ContextCompat.checkSelfPermission(
+            context,
+            permission,
+        ) == PackageManager.PERMISSION_GRANTED
+    }
 
     fun shouldShowRequestPermissionRationale(activity: Activity?): Boolean {
         if (activity == null) return false

--- a/core/permission/src/main/java/com/chac/core/permission/compose/ComposePermissionUtils.kt
+++ b/core/permission/src/main/java/com/chac/core/permission/compose/ComposePermissionUtils.kt
@@ -21,11 +21,10 @@ import com.chac.core.permission.PermissionUtil.PermissionState
 @Composable
 internal fun rememberRegisterPermission(onPermissionResult: (PermissionState) -> Unit): Permission {
     val activity = LocalActivity.current
-    val register =
-        rememberLauncherForActivityResult(
-            contract = ActivityResultContracts.RequestMultiplePermissions(),
-            onResult = { onPermissionResult(getPermissionState(activity = activity, result = it)) },
-        )
+    val register = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestMultiplePermissions(),
+        onResult = { onPermissionResult(getPermissionState(activity = activity, result = it)) },
+    )
     return Permission(register)
 }
 
@@ -34,15 +33,13 @@ fun rememberRegisterMediaWithLocationPermission(
     onGranted: () -> Unit,
     onDenied: (() -> Unit)? = null,
     onPermanentlyDenied: (() -> Unit)? = null,
-): Permission =
-    rememberRegisterPermission(
-        onPermissionResult =
-            getPermissionResultListener(
-                onGranted = onGranted,
-                onDenied = onDenied,
-                onPermanentlyDenied = onPermanentlyDenied,
-            ),
-    )
+): Permission = rememberRegisterPermission(
+    onPermissionResult = getPermissionResultListener(
+        onGranted = onGranted,
+        onDenied = onDenied,
+        onPermanentlyDenied = onPermanentlyDenied,
+    ),
+)
 
 @Composable
 fun PermissionDeniedDialog(
@@ -71,9 +68,8 @@ fun PermissionDeniedDialog(
 
 fun moveToPermissionSetting(context: Context) {
     try {
-        val intent =
-            Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
-                .setData("package:${context.packageName}".toUri())
+        val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+            .setData("package:${context.packageName}".toUri())
         context.startActivity(intent)
     } catch (e: ActivityNotFoundException) {
         val intent = Intent(Settings.ACTION_MANAGE_APPLICATIONS_SETTINGS)

--- a/data/album/src/main/java/com/chac/data/album/media/MediaDataSource.kt
+++ b/data/album/src/main/java/com/chac/data/album/media/MediaDataSource.kt
@@ -13,110 +13,106 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
-internal class MediaDataSource
-    @Inject
-    constructor(
-        @ApplicationContext private val context: Context,
-    ) {
-        private val contentResolver = context.contentResolver
-        private val ioDispatcher = Dispatchers.IO
+internal class MediaDataSource @Inject constructor(
+    @ApplicationContext private val context: Context,
+) {
+    private val contentResolver = context.contentResolver
+    private val ioDispatcher = Dispatchers.IO
 
-        suspend fun getMedia(
-            startTime: Long,
-            endTime: Long,
-            mediaType: MediaType,
-            mediaSortOrder: MediaSortOrder,
-        ): List<Media> =
-            withContext(ioDispatcher) {
-                val items = mutableListOf<Media>()
+    suspend fun getMedia(
+        startTime: Long,
+        endTime: Long,
+        mediaType: MediaType,
+        mediaSortOrder: MediaSortOrder,
+    ): List<Media> = withContext(ioDispatcher) {
+        val items = mutableListOf<Media>()
 
-                val projection = arrayOf(
-                    MediaStore.Files.FileColumns._ID,
-                    MediaStore.Files.FileColumns.DATE_TAKEN,
-                    MediaStore.Files.FileColumns.MEDIA_TYPE,
-                )
+        val projection = arrayOf(
+            MediaStore.Files.FileColumns._ID,
+            MediaStore.Files.FileColumns.DATE_TAKEN,
+            MediaStore.Files.FileColumns.MEDIA_TYPE,
+        )
 
-                // 미디어 타입 필터 설정
-                val typeSelection = when (mediaType) {
-                    MediaType.IMAGE -> "${MediaStore.Files.FileColumns.MEDIA_TYPE} = ${MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE}"
-                    MediaType.VIDEO -> "${MediaStore.Files.FileColumns.MEDIA_TYPE} = ${MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO}"
-                    MediaType.ALL ->
-                        "(${MediaStore.Files.FileColumns.MEDIA_TYPE} = ${MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE} OR " +
-                            "${MediaStore.Files.FileColumns.MEDIA_TYPE} = ${MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO})"
-                }
+        // 미디어 타입 필터 설정
+        val typeSelection = when (mediaType) {
+            MediaType.IMAGE -> "${MediaStore.Files.FileColumns.MEDIA_TYPE} = ${MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE}"
+            MediaType.VIDEO -> "${MediaStore.Files.FileColumns.MEDIA_TYPE} = ${MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO}"
+            MediaType.ALL ->
+                "(${MediaStore.Files.FileColumns.MEDIA_TYPE} = ${MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE} OR " +
+                    "${MediaStore.Files.FileColumns.MEDIA_TYPE} = ${MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO})"
+        }
 
-                // 시간 필터 설정
-                val timeSelection = "${MediaStore.Files.FileColumns.DATE_TAKEN} IS NOT NULL AND " +
-                    "${MediaStore.Files.FileColumns.DATE_TAKEN} > 0 AND " +
-                    "${MediaStore.Files.FileColumns.DATE_TAKEN} >= ? AND " +
-                    "${MediaStore.Files.FileColumns.DATE_TAKEN} <= ?"
+        // 시간 필터 설정
+        val timeSelection = "${MediaStore.Files.FileColumns.DATE_TAKEN} IS NOT NULL AND " +
+            "${MediaStore.Files.FileColumns.DATE_TAKEN} > 0 AND " +
+            "${MediaStore.Files.FileColumns.DATE_TAKEN} >= ? AND " +
+            "${MediaStore.Files.FileColumns.DATE_TAKEN} <= ?"
 
-                // 최종 쿼리 조건 구성
-                val selection = "$typeSelection AND $timeSelection"
-                val selectionArgs = arrayOf(startTime.toString(), endTime.toString())
+        // 최종 쿼리 조건 구성
+        val selection = "$typeSelection AND $timeSelection"
+        val selectionArgs = arrayOf(startTime.toString(), endTime.toString())
 
-                // 정렬 설정
-                val mediaSortOrderSQL = when (mediaSortOrder) {
-                    MediaSortOrder.NEWEST_FIRST -> "${MediaStore.Files.FileColumns.DATE_TAKEN} DESC"
-                    MediaSortOrder.OLDEST_FIRST -> "${MediaStore.Files.FileColumns.DATE_TAKEN} ASC"
-                }
+        // 정렬 설정
+        val mediaSortOrderSQL = when (mediaSortOrder) {
+            MediaSortOrder.NEWEST_FIRST -> "${MediaStore.Files.FileColumns.DATE_TAKEN} DESC"
+            MediaSortOrder.OLDEST_FIRST -> "${MediaStore.Files.FileColumns.DATE_TAKEN} ASC"
+        }
 
-                var cursor: Cursor? = null
+        var cursor: Cursor? = null
 
-                try {
-                    cursor = contentResolver.query(
+        try {
+            cursor = contentResolver.query(
+                MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL),
+                projection,
+                selection,
+                selectionArgs,
+                mediaSortOrderSQL,
+            )
+
+            cursor?.let {
+                val idColumn = it.getColumnIndexOrThrow(MediaStore.Files.FileColumns._ID)
+                val dateTakenColumn = it.getColumnIndexOrThrow(MediaStore.Files.FileColumns.DATE_TAKEN)
+                val mediaTypeColumn = it.getColumnIndexOrThrow(MediaStore.Files.FileColumns.MEDIA_TYPE)
+
+                while (it.moveToNext()) {
+                    val id = it.getLong(idColumn)
+                    val dateTaken = it.getLong(dateTakenColumn)
+                    val mediaTypeValue = it.getInt(mediaTypeColumn)
+
+                    // DATE_TAKEN이 유효하지 않은 경우 무시
+                    if (dateTaken <= 0) continue
+
+                    val uri = ContentUris.withAppendedId(
                         MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL),
-                        projection,
-                        selection,
-                        selectionArgs,
-                        mediaSortOrderSQL,
+                        id,
                     )
 
-                    cursor?.let {
-                        val idColumn = it.getColumnIndexOrThrow(MediaStore.Files.FileColumns._ID)
-                        val dateTakenColumn = it.getColumnIndexOrThrow(MediaStore.Files.FileColumns.DATE_TAKEN)
-                        val mediaTypeColumn = it.getColumnIndexOrThrow(MediaStore.Files.FileColumns.MEDIA_TYPE)
-
-                        while (it.moveToNext()) {
-                            val id = it.getLong(idColumn)
-                            val dateTaken = it.getLong(dateTakenColumn)
-                            val mediaTypeValue = it.getInt(mediaTypeColumn)
-
-                            // DATE_TAKEN이 유효하지 않은 경우 무시
-                            if (dateTaken <= 0) continue
-
-                            val uri = ContentUris.withAppendedId(
-                                MediaStore.Files.getContentUri(MediaStore.VOLUME_EXTERNAL),
-                                id,
-                            )
-
-                            val type = when (mediaTypeValue) {
-                                MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE -> MediaType.IMAGE
-                                MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO -> MediaType.VIDEO
-                                else -> MediaType.IMAGE
-                            }
-
-                            items.add(
-                                Media(
-                                    id = id,
-                                    uriString = uri.toString(),
-                                    dateTaken = dateTaken,
-                                    mediaType = type,
-                                ),
-                            )
-                        }
+                    val type = when (mediaTypeValue) {
+                        MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE -> MediaType.IMAGE
+                        MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO -> MediaType.VIDEO
+                        else -> MediaType.IMAGE
                     }
-                } catch (e: Exception) {
-                    e.printStackTrace()
-                } finally {
-                    cursor?.close()
+
+                    items.add(
+                        Media(
+                            id = id,
+                            uriString = uri.toString(),
+                            dateTaken = dateTaken,
+                            mediaType = type,
+                        ),
+                    )
                 }
-
-                items
             }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        } finally {
+            cursor?.close()
+        }
 
-        suspend fun getMediaLocation(uri: String): MediaLocation? =
-            withContext(ioDispatcher) {
-                getMediaLocation(context, uri)
-            }
+        items
     }
+
+    suspend fun getMediaLocation(uri: String): MediaLocation? = withContext(ioDispatcher) {
+        getMediaLocation(context, uri)
+    }
+}

--- a/data/album/src/main/java/com/chac/data/album/media/MediaRepositoryImpl.kt
+++ b/data/album/src/main/java/com/chac/data/album/media/MediaRepositoryImpl.kt
@@ -21,119 +21,114 @@ import javax.inject.Inject
  * 계산된 클러스터에는 중심 좌표를 리버스 지오코딩한 제목이 포함된다.
  * [getClusteredMediaStream]은 계산 결과를 캐시에 저장해 이후 수집자에게 재사용한다.
  */
-internal class MediaRepositoryImpl
-    @Inject
-    constructor(
-        @TimeBasedClustering
-        private val timeBasedClusteringStrategy: ClusteringStrategy,
-        @LocationBasedClustering
-        private val locationBasedClusteringStrategy: ClusteringStrategy,
-        private val reverseGeocoder: ReverseGeocoder,
-        private val dataSource: MediaDataSource,
-    ) : MediaRepository {
-        /** [cachedClusteredMedia]에 접근할 때 동시성 문제를 방지하기 위한 Lock 객체 */
-        private val cacheLock = Any()
+internal class MediaRepositoryImpl @Inject constructor(
+    @TimeBasedClustering
+    private val timeBasedClusteringStrategy: ClusteringStrategy,
+    @LocationBasedClustering
+    private val locationBasedClusteringStrategy: ClusteringStrategy,
+    private val reverseGeocoder: ReverseGeocoder,
+    private val dataSource: MediaDataSource,
+) : MediaRepository {
+    /** [cachedClusteredMedia]에 접근할 때 동시성 문제를 방지하기 위한 Lock 객체 */
+    private val cacheLock = Any()
 
-        /** 클러스터의 캐시 데이터 */
-        private var cachedClusteredMedia: List<MediaCluster>? = null
+    /** 클러스터의 캐시 데이터 */
+    private var cachedClusteredMedia: List<MediaCluster>? = null
 
-        override fun getClusteredMediaStream(): Flow<MediaCluster> =
-            flow {
-                val cached = synchronized(cacheLock) { cachedClusteredMedia }
-                if (cached != null) {
-                    cached.forEach { cluster ->
-                        emit(cluster)
-                    }
-                    return@flow
-                }
-
-                val result = createClusteredMedia { cluster ->
-                    emit(cluster)
-                }
-                synchronized(cacheLock) {
-                    cachedClusteredMedia = result
-                }
+    override fun getClusteredMediaStream(): Flow<MediaCluster> = flow {
+        val cached = synchronized(cacheLock) { cachedClusteredMedia }
+        if (cached != null) {
+            cached.forEach { cluster ->
+                emit(cluster)
             }
-
-        private suspend fun createClusteredMedia(
-            onCluster: suspend (MediaCluster) -> Unit = {},
-        ): List<MediaCluster> {
-            val starTime = System.currentTimeMillis()
-            Timber.d("MediaRepositoryImpl, getClusteredMedia call")
-
-            val timeBasedClusters = timeBasedClusteringStrategy.cluster(getMedia())
-
-            val step1Time = System.currentTimeMillis()
-            Timber.d(
-                "MediaRepositoryImpl, time base clusters-${timeBasedClusters.size}," +
-                    "mediaCounts-${timeBasedClusters.values.flatten().size}, time = ${step1Time - starTime}",
-            )
-
-            // TODO 이렇게 캐싱 없이 한번에 exif에서 LatLng를 가져오는 방식은 오래걸려서 개선해야함.
-            val mediaClusters = mutableListOf<MediaCluster>()
-            timeBasedClusters.values.forEach { mediaInTimeCluster ->
-                val locationBasedClusters = locationBasedClusteringStrategy.cluster(mediaInTimeCluster)
-                locationBasedClusters.forEach { (keyTime, mediaList) ->
-                    val title = getClusterTitle(mediaList)
-                    val cluster = MediaCluster(
-                        id = keyTime,
-                        mediaList = mediaList,
-                        title = title,
-                    )
-                    mediaClusters.add(cluster)
-                    onCluster(cluster)
-                }
-            }
-
-            val step2Time = System.currentTimeMillis()
-            Timber.d(
-                "MediaRepositoryImpl, locationBasedClusters-${mediaClusters.size}," +
-                    "mediaCounts-${mediaClusters.flatMap { it.mediaList }.size}, time = ${step2Time - step1Time}",
-            )
-
-            return mediaClusters
+            return@flow
         }
 
-        override suspend fun getMedia(
-            startTime: Long,
-            endTime: Long,
-            mediaType: MediaType,
-            mediaSortOrder: MediaSortOrder,
-        ): List<Media> =
-            dataSource.getMedia(
-                startTime = startTime,
-                endTime = endTime,
-                mediaType = mediaType,
-                mediaSortOrder = mediaSortOrder,
-            )
-
-        override suspend fun getMediaLocation(uri: String): MediaLocation? = dataSource.getMediaLocation(uri)
-
-
-        private suspend fun getClusterTitle(mediaList: List<Media>): String {
-            val centroid = getClusterCentroid(mediaList) ?: return ""
-            return reverseGeocoder.reverseGeocode(centroid).orEmpty()
+        val result = createClusteredMedia { cluster ->
+            emit(cluster)
         }
-
-        private suspend fun getClusterCentroid(mediaList: List<Media>): MediaLocation? {
-            var sumLatitude = 0.0
-            var sumLongitude = 0.0
-            var count = 0
-            mediaList.forEach { media ->
-                val location = dataSource.getMediaLocation(media.uriString)
-                val latitude = location?.latitude
-                val longitude = location?.longitude
-                if (latitude != null && longitude != null) {
-                    sumLatitude += latitude
-                    sumLongitude += longitude
-                    count += 1
-                }
-            }
-
-            if (count == 0) return null
-            return MediaLocation(
-                latitude = sumLatitude / count,
-                longitude = sumLongitude / count,
-            )
+        synchronized(cacheLock) {
+            cachedClusteredMedia = result
         }
     }
+
+    private suspend fun createClusteredMedia(
+        onCluster: suspend (MediaCluster) -> Unit = {},
+    ): List<MediaCluster> {
+        val starTime = System.currentTimeMillis()
+        Timber.d("MediaRepositoryImpl, getClusteredMedia call")
+
+        val timeBasedClusters = timeBasedClusteringStrategy.cluster(getMedia())
+
+        val step1Time = System.currentTimeMillis()
+        Timber.d(
+            "MediaRepositoryImpl, time base clusters-${timeBasedClusters.size}," +
+                "mediaCounts-${timeBasedClusters.values.flatten().size}, time = ${step1Time - starTime}",
+        )
+
+        // TODO 이렇게 캐싱 없이 한번에 exif에서 LatLng를 가져오는 방식은 오래걸려서 개선해야함.
+        val mediaClusters = mutableListOf<MediaCluster>()
+        timeBasedClusters.values.forEach { mediaInTimeCluster ->
+            val locationBasedClusters = locationBasedClusteringStrategy.cluster(mediaInTimeCluster)
+            locationBasedClusters.forEach { (keyTime, mediaList) ->
+                val title = getClusterTitle(mediaList)
+                val cluster = MediaCluster(
+                    id = keyTime,
+                    mediaList = mediaList,
+                    title = title,
+                )
+                mediaClusters.add(cluster)
+                onCluster(cluster)
+            }
+        }
+
+        val step2Time = System.currentTimeMillis()
+        Timber.d(
+            "MediaRepositoryImpl, locationBasedClusters-${mediaClusters.size}," +
+                "mediaCounts-${mediaClusters.flatMap { it.mediaList }.size}, time = ${step2Time - step1Time}",
+        )
+
+        return mediaClusters
+    }
+
+    override suspend fun getMedia(
+        startTime: Long,
+        endTime: Long,
+        mediaType: MediaType,
+        mediaSortOrder: MediaSortOrder,
+    ): List<Media> = dataSource.getMedia(
+        startTime = startTime,
+        endTime = endTime,
+        mediaType = mediaType,
+        mediaSortOrder = mediaSortOrder,
+    )
+
+    override suspend fun getMediaLocation(uri: String): MediaLocation? = dataSource.getMediaLocation(uri)
+
+    private suspend fun getClusterTitle(mediaList: List<Media>): String {
+        val centroid = getClusterCentroid(mediaList) ?: return ""
+        return reverseGeocoder.reverseGeocode(centroid).orEmpty()
+    }
+
+    private suspend fun getClusterCentroid(mediaList: List<Media>): MediaLocation? {
+        var sumLatitude = 0.0
+        var sumLongitude = 0.0
+        var count = 0
+        mediaList.forEach { media ->
+            val location = dataSource.getMediaLocation(media.uriString)
+            val latitude = location?.latitude
+            val longitude = location?.longitude
+            if (latitude != null && longitude != null) {
+                sumLatitude += latitude
+                sumLongitude += longitude
+                count += 1
+            }
+        }
+
+        if (count == 0) return null
+        return MediaLocation(
+            latitude = sumLatitude / count,
+            longitude = sumLongitude / count,
+        )
+    }
+}

--- a/data/album/src/main/java/com/chac/data/album/media/clustering/ClusteringStrategy.kt
+++ b/data/album/src/main/java/com/chac/data/album/media/clustering/ClusteringStrategy.kt
@@ -20,10 +20,9 @@ abstract class ClusteringStrategy {
 
     protected abstract suspend fun performClustering(mediaList: List<Media>): Map<Long, List<Media>>
 
-    protected fun filterByMinSize(clusters: Map<Long, List<Media>>): Map<Long, List<Media>> =
-        clusters.filter { (_, cluster) ->
-            cluster.size >= minClusterSize
-        }
+    protected fun filterByMinSize(clusters: Map<Long, List<Media>>): Map<Long, List<Media>> = clusters.filter { (_, cluster) ->
+        cluster.size >= minClusterSize
+    }
 
     companion object {
         const val DEFAULT_MIN_CLUSTER_SIZE: Int = 20

--- a/data/album/src/main/java/com/chac/data/album/media/clustering/LocationBasedClusteringStrategy.kt
+++ b/data/album/src/main/java/com/chac/data/album/media/clustering/LocationBasedClusteringStrategy.kt
@@ -12,81 +12,79 @@ import org.apache.commons.math3.ml.clustering.DoublePoint
 import org.apache.commons.math3.ml.distance.EuclideanDistance
 import javax.inject.Inject
 
-class LocationBasedClusteringStrategy
-    @Inject
-    constructor(
-        @ApplicationContext private val context: Context,
-    ) : ClusteringStrategy() {
-        private val epsilon = DEFAULT_EPSILON
-        private val minPoints = DEFAULT_MIN_POINTS
-        private val batchSize = LOCATION_FETCH_BATCH_SIZE
+class LocationBasedClusteringStrategy @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : ClusteringStrategy() {
+    private val epsilon = DEFAULT_EPSILON
+    private val minPoints = DEFAULT_MIN_POINTS
+    private val batchSize = LOCATION_FETCH_BATCH_SIZE
 
-        override suspend fun performClustering(mediaList: List<Media>): Map<Long, List<Media>> {
-            if (mediaList.isEmpty()) return emptyMap()
+    override suspend fun performClustering(mediaList: List<Media>): Map<Long, List<Media>> {
+        if (mediaList.isEmpty()) return emptyMap()
 
-            // 위치 정보 병렬 처리 및 위치 정보가 있는 미디어만 필터링
-            val mediaWithLocations = coroutineScope {
-                mediaList.chunked(batchSize).flatMap { batch ->
-                    batch
-                        .map { media ->
-                            async {
-                                val location = getMediaLocation(context, media.uriString)
-                                if (location?.latitude != null && location.longitude != null) {
-                                    Pair(media, location)
-                                } else {
-                                    null
-                                }
+        // 위치 정보 병렬 처리 및 위치 정보가 있는 미디어만 필터링
+        val mediaWithLocations = coroutineScope {
+            mediaList.chunked(batchSize).flatMap { batch ->
+                batch
+                    .map { media ->
+                        async {
+                            val location = getMediaLocation(context, media.uriString)
+                            if (location?.latitude != null && location.longitude != null) {
+                                Pair(media, location)
+                            } else {
+                                null
                             }
-                        }.awaitAll()
-                        .filterNotNull()
-                }
+                        }
+                    }.awaitAll()
+                    .filterNotNull()
             }
+        }
 
-            if (mediaWithLocations.isEmpty()) return emptyMap()
+        if (mediaWithLocations.isEmpty()) return emptyMap()
 
-            // DBSCAN 클러스터링을 위한 LocationPoint 생성
-            val locationPoints = mediaWithLocations.map { (media, location) ->
-                LocationPoint(
-                    doubleArrayOf(
-                        location.latitude ?: 0.0,
-                        location.longitude ?: 0.0,
-                    ),
-                    media,
-                )
-            }
-
-            // Apache Commons Math3의 DBSCANClusterer를 사용하여 클러스터링 수행
-            val clusterer = DBSCANClusterer<LocationPoint>(
-                epsilon,
-                minPoints,
-                EuclideanDistance(),
+        // DBSCAN 클러스터링을 위한 LocationPoint 생성
+        val locationPoints = mediaWithLocations.map { (media, location) ->
+            LocationPoint(
+                doubleArrayOf(
+                    location.latitude ?: 0.0,
+                    location.longitude ?: 0.0,
+                ),
+                media,
             )
+        }
 
-            val clusters = clusterer.cluster(locationPoints)
+        // Apache Commons Math3의 DBSCANClusterer를 사용하여 클러스터링 수행
+        val clusterer = DBSCANClusterer<LocationPoint>(
+            epsilon,
+            minPoints,
+            EuclideanDistance(),
+        )
 
-            // 결과 맵 구성 (키: 클러스터 내 첫 번째 미디어의 dateTaken, 값: 미디어 리스트)
-            val resultClusters = mutableMapOf<Long, List<Media>>()
-            clusters.forEachIndexed { _, cluster ->
-                if (cluster.points.isNotEmpty()) {
-                    val clusterMedia = cluster.points.map { it.media }
-                    // 클러스터의 첫 번째 미디어의 dateTaken을 키로 사용
-                    val clusterKey = clusterMedia.first().dateTaken
-                    resultClusters[clusterKey] = clusterMedia
-                }
+        val clusters = clusterer.cluster(locationPoints)
+
+        // 결과 맵 구성 (키: 클러스터 내 첫 번째 미디어의 dateTaken, 값: 미디어 리스트)
+        val resultClusters = mutableMapOf<Long, List<Media>>()
+        clusters.forEachIndexed { _, cluster ->
+            if (cluster.points.isNotEmpty()) {
+                val clusterMedia = cluster.points.map { it.media }
+                // 클러스터의 첫 번째 미디어의 dateTaken을 키로 사용
+                val clusterKey = clusterMedia.first().dateTaken
+                resultClusters[clusterKey] = clusterMedia
             }
-
-            return resultClusters
         }
 
-        // 위치 정보와 미디어를 함께 가지는 DoublePoint 확장 클래스
-        private class LocationPoint(
-            points: DoubleArray,
-            val media: Media,
-        ) : DoublePoint(points)
-
-        companion object {
-            const val DEFAULT_EPSILON: Double = 0.03
-            const val DEFAULT_MIN_POINTS: Int = 1
-            const val LOCATION_FETCH_BATCH_SIZE: Int = 20
-        }
+        return resultClusters
     }
+
+    // 위치 정보와 미디어를 함께 가지는 DoublePoint 확장 클래스
+    private class LocationPoint(
+        points: DoubleArray,
+        val media: Media,
+    ) : DoublePoint(points)
+
+    companion object {
+        const val DEFAULT_EPSILON: Double = 0.03
+        const val DEFAULT_MIN_POINTS: Int = 1
+        const val LOCATION_FETCH_BATCH_SIZE: Int = 20
+    }
+}

--- a/data/album/src/main/java/com/chac/data/album/media/clustering/TimeBasedClusteringStrategy.kt
+++ b/data/album/src/main/java/com/chac/data/album/media/clustering/TimeBasedClusteringStrategy.kt
@@ -3,72 +3,70 @@ package com.chac.data.album.media.clustering
 import com.chac.domain.album.media.Media
 import javax.inject.Inject
 
-class TimeBasedClusteringStrategy
-    @Inject
-    constructor() : ClusteringStrategy() {
-        private val maxTimeDifference = DEFAULT_MAX_TIME_DIFFERENCE
+class TimeBasedClusteringStrategy @Inject constructor() : ClusteringStrategy() {
+    private val maxTimeDifference = DEFAULT_MAX_TIME_DIFFERENCE
 
-        override suspend fun performClustering(mediaList: List<Media>): Map<Long, List<Media>> {
-            if (mediaList.isEmpty()) return emptyMap()
+    override suspend fun performClustering(mediaList: List<Media>): Map<Long, List<Media>> {
+        if (mediaList.isEmpty()) return emptyMap()
 
-            // 최신순으로 정렬
-            val sortedMedia = mediaList.sortedByDescending { it.dateTaken }
+        // 최신순으로 정렬
+        val sortedMedia = mediaList.sortedByDescending { it.dateTaken }
 
-            // 결과 맵 (키: 클러스터 시작 시간, 값: 미디어 리스트)
-            val resultClusters = mutableMapOf<Long, MutableList<Media>>()
+        // 결과 맵 (키: 클러스터 시작 시간, 값: 미디어 리스트)
+        val resultClusters = mutableMapOf<Long, MutableList<Media>>()
 
-            var currentClusterStartTime: Long? = null
-            var currentCluster = mutableListOf<Media>()
-            var remainingMedia = sortedMedia.size
+        var currentClusterStartTime: Long? = null
+        var currentCluster = mutableListOf<Media>()
+        var remainingMedia = sortedMedia.size
 
-            // 시간 차이에 따라 미디어 아이템 그룹화
-            for (i in sortedMedia.indices) {
-                val currentMedia = sortedMedia[i]
+        // 시간 차이에 따라 미디어 아이템 그룹화
+        for (i in sortedMedia.indices) {
+            val currentMedia = sortedMedia[i]
 
-                // 새 클러스터 시작 여부 결정
-                if (currentCluster.isEmpty()) {
-                    currentCluster.add(currentMedia)
-                    currentClusterStartTime = currentMedia.dateTaken
-                    remainingMedia--
-                    continue
-                }
-
-                val previousMedia = sortedMedia[i - 1]
-                val timeDifference = previousMedia.dateTaken - currentMedia.dateTaken
-
-                // 시간 차이가 임계값을 초과하면 현재 클러스터 처리
-                if (timeDifference > maxTimeDifference) {
-                    // 현재 클러스터가 최소 크기를 충족하는 경우에만 결과에 추가
-                    if (currentCluster.size >= minClusterSize) {
-                        resultClusters[currentClusterStartTime!!] = currentCluster
-                    }
-
-                    // 새 클러스터 시작 - 남은 미디어 항목이 최소 크기보다 적으면 더 이상 유효한 클러스터가 불가능
-                    if (remainingMedia < minClusterSize) {
-                        // 더 이상 처리할 필요가 없으므로 반복 종료
-                        break
-                    }
-
-                    // 새 클러스터 초기화
-                    currentCluster = mutableListOf(currentMedia)
-                    currentClusterStartTime = currentMedia.dateTaken
-                } else {
-                    // 현재 클러스터에 추가
-                    currentCluster.add(currentMedia)
-                }
-
+            // 새 클러스터 시작 여부 결정
+            if (currentCluster.isEmpty()) {
+                currentCluster.add(currentMedia)
+                currentClusterStartTime = currentMedia.dateTaken
                 remainingMedia--
+                continue
             }
 
-            // 마지막 클러스터가 최소 크기를 충족하는 경우에만 결과에 추가
-            if (currentCluster.size >= minClusterSize && currentClusterStartTime != null) {
-                resultClusters[currentClusterStartTime] = currentCluster
+            val previousMedia = sortedMedia[i - 1]
+            val timeDifference = previousMedia.dateTaken - currentMedia.dateTaken
+
+            // 시간 차이가 임계값을 초과하면 현재 클러스터 처리
+            if (timeDifference > maxTimeDifference) {
+                // 현재 클러스터가 최소 크기를 충족하는 경우에만 결과에 추가
+                if (currentCluster.size >= minClusterSize) {
+                    resultClusters[currentClusterStartTime!!] = currentCluster
+                }
+
+                // 새 클러스터 시작 - 남은 미디어 항목이 최소 크기보다 적으면 더 이상 유효한 클러스터가 불가능
+                if (remainingMedia < minClusterSize) {
+                    // 더 이상 처리할 필요가 없으므로 반복 종료
+                    break
+                }
+
+                // 새 클러스터 초기화
+                currentCluster = mutableListOf(currentMedia)
+                currentClusterStartTime = currentMedia.dateTaken
+            } else {
+                // 현재 클러스터에 추가
+                currentCluster.add(currentMedia)
             }
 
-            return resultClusters
+            remainingMedia--
         }
 
-        companion object {
-            const val DEFAULT_MAX_TIME_DIFFERENCE: Long = 3 * 60 * 60 * 1000 // 3 hours in milliseconds
+        // 마지막 클러스터가 최소 크기를 충족하는 경우에만 결과에 추가
+        if (currentCluster.size >= minClusterSize && currentClusterStartTime != null) {
+            resultClusters[currentClusterStartTime] = currentCluster
         }
+
+        return resultClusters
     }
+
+    companion object {
+        const val DEFAULT_MAX_TIME_DIFFERENCE: Long = 3 * 60 * 60 * 1000 // 3 hours in milliseconds
+    }
+}

--- a/data/album/src/main/java/com/chac/data/album/media/reversGeocoder/AndroidReverseGeocoder.kt
+++ b/data/album/src/main/java/com/chac/data/album/media/reversGeocoder/AndroidReverseGeocoder.kt
@@ -21,73 +21,70 @@ import kotlin.coroutines.resume
  *
  * @param context 애플리케이션 컨텍스트
  */
-internal class AndroidReverseGeocoder
-    @Inject
-    constructor(
-        @ApplicationContext private val context: Context,
-    ) : ReverseGeocoder {
-        /**
-         * 위/경도에 대한 주소 문자열을 조회한다.
-         *
-         * @param location 조회할 위치 정보
-         * @return 주소 문자열. 조회 실패 시 null
-         */
-        override suspend fun reverseGeocode(location: MediaLocation): String? {
-            val latitude = location.latitude ?: return null
-            val longitude = location.longitude ?: return null
-            return withContext(Dispatchers.IO) {
-                if (!Geocoder.isPresent()) return@withContext null
-                val address =
-                    runCatching {
-                        val geocoder = Geocoder(context, Locale.getDefault())
-                        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                            geocodeAsync(geocoder, latitude, longitude)
-                        } else {
-                            @Suppress("DEPRECATION")
-                            geocoder.getFromLocation(latitude, longitude, 1)?.firstOrNull()
-                        }
-                    }.getOrNull()
-                address?.let { address ->
-                    address.subLocality
-                        ?: address.locality
-                        ?: address.adminArea
-                        ?: address.countryName
-                        ?: address.getAddressLine(0)
+internal class AndroidReverseGeocoder @Inject constructor(
+    @ApplicationContext private val context: Context,
+) : ReverseGeocoder {
+    /**
+     * 위/경도에 대한 주소 문자열을 조회한다.
+     *
+     * @param location 조회할 위치 정보
+     * @return 주소 문자열. 조회 실패 시 null
+     */
+    override suspend fun reverseGeocode(location: MediaLocation): String? {
+        val latitude = location.latitude ?: return null
+        val longitude = location.longitude ?: return null
+        return withContext(Dispatchers.IO) {
+            if (!Geocoder.isPresent()) return@withContext null
+            val address = runCatching {
+                val geocoder = Geocoder(context, Locale.getDefault())
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    geocodeAsync(geocoder, latitude, longitude)
+                } else {
+                    @Suppress("DEPRECATION")
+                    geocoder.getFromLocation(latitude, longitude, 1)?.firstOrNull()
                 }
+            }.getOrNull()
+            address?.let { address ->
+                address.subLocality
+                    ?: address.locality
+                    ?: address.adminArea
+                    ?: address.countryName
+                    ?: address.getAddressLine(0)
             }
         }
-
-        /**
-         * API 33 이상에서 비동기 Geocoder 호출을 suspend 형태로 래핑한다.
-         *
-         * @param geocoder 사용할 Geocoder 인스턴스
-         * @param latitude 위도
-         * @param longitude 경도
-         * @return 첫 번째 주소. 조회 실패 시 null
-         */
-        @RequiresApi(Build.VERSION_CODES.TIRAMISU)
-        private suspend fun geocodeAsync(
-            geocoder: Geocoder,
-            latitude: Double,
-            longitude: Double,
-        ) = suspendCancellableCoroutine { continuation ->
-            geocoder.getFromLocation(
-                latitude,
-                longitude,
-                1,
-                object : Geocoder.GeocodeListener {
-                    override fun onGeocode(addresses: MutableList<Address>) {
-                        if (continuation.isActive) {
-                            continuation.resume(addresses.firstOrNull())
-                        }
-                    }
-
-                    override fun onError(errorMessage: String?) {
-                        if (continuation.isActive) {
-                            continuation.resume(null)
-                        }
-                    }
-                },
-            )
-        }
     }
+
+    /**
+     * API 33 이상에서 비동기 Geocoder 호출을 suspend 형태로 래핑한다.
+     *
+     * @param geocoder 사용할 Geocoder 인스턴스
+     * @param latitude 위도
+     * @param longitude 경도
+     * @return 첫 번째 주소. 조회 실패 시 null
+     */
+    @RequiresApi(Build.VERSION_CODES.TIRAMISU)
+    private suspend fun geocodeAsync(
+        geocoder: Geocoder,
+        latitude: Double,
+        longitude: Double,
+    ) = suspendCancellableCoroutine { continuation ->
+        geocoder.getFromLocation(
+            latitude,
+            longitude,
+            1,
+            object : Geocoder.GeocodeListener {
+                override fun onGeocode(addresses: MutableList<Address>) {
+                    if (continuation.isActive) {
+                        continuation.resume(addresses.firstOrNull())
+                    }
+                }
+
+                override fun onError(errorMessage: String?) {
+                    if (continuation.isActive) {
+                        continuation.resume(null)
+                    }
+                }
+            },
+        )
+    }
+}

--- a/domain/album/src/main/java/com/chac/domain/album/media/GetClusteredMediaStreamUseCase.kt
+++ b/domain/album/src/main/java/com/chac/domain/album/media/GetClusteredMediaStreamUseCase.kt
@@ -8,10 +8,8 @@ import javax.inject.Inject
  *
  * @return 클러스터 UI 표시를 위한 스트림
  */
-class GetClusteredMediaStreamUseCase
-    @Inject
-    constructor(
-        private val mediaRepository: MediaRepository,
-    ) {
-        operator fun invoke(): Flow<MediaCluster> = mediaRepository.getClusteredMediaStream()
-    }
+class GetClusteredMediaStreamUseCase @Inject constructor(
+    private val mediaRepository: MediaRepository,
+) {
+    operator fun invoke(): Flow<MediaCluster> = mediaRepository.getClusteredMediaStream()
+}

--- a/feature/album/src/main/java/com/chac/feature/album/clustering/ClusteringViewModel.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/clustering/ClusteringViewModel.kt
@@ -16,73 +16,69 @@ import javax.inject.Inject
 
 /** 클러스터링 화면 상태를 제공하는 ViewModel */
 @HiltViewModel
-class ClusteringViewModel
-    @Inject
-    constructor(
-        private val getClusteredMediaStreamUseCase: GetClusteredMediaStreamUseCase,
-    ) : ViewModel() {
+class ClusteringViewModel @Inject constructor(
+    private val getClusteredMediaStreamUseCase: GetClusteredMediaStreamUseCase,
+) : ViewModel() {
+    /** 클러스터링 화면의 상태 */
+    private val _uiState = MutableStateFlow<ClusteringUiState>(ClusteringUiState.PermissionChecking)
+    val uiState: StateFlow<ClusteringUiState> = _uiState.asStateFlow()
 
-        /** 클러스터링 화면의 상태 */
-        private val _uiState = MutableStateFlow<ClusteringUiState>(ClusteringUiState.PermissionChecking)
-        val uiState: StateFlow<ClusteringUiState> = _uiState.asStateFlow()
+    /**
+     * 클러스터 스트림 수집의 예외 처리를 위한 Job
+     *
+     * 1. 클러스터 스트림 중복 수집 방지
+     * 2. 수집이 진행중일 때 권한이 거절되면 캔슬
+     */
+    private var clusterCollectJob: Job? = null
 
-        /**
-         * 클러스터 스트림 수집의 예외 처리를 위한 Job
-         *
-         * 1. 클러스터 스트림 중복 수집 방지
-         * 2. 수집이 진행중일 때 권한이 거절되면 캔슬
-         */
-        private var clusterCollectJob: Job? = null
-
-        /**
-         * 권한 변경 결과를 반영해 UI 상태와 스트림 수집을 갱신한다.
-         *
-         * @param hasPermission 권한 허용 여부
-         */
-        fun onPermissionChanged(hasPermission: Boolean) {
-            if (!hasPermission) {
-                clusterCollectJob?.cancel()
-                clusterCollectJob = null
-                _uiState.value = ClusteringUiState.PermissionDenied
-                return
-            }
-
-            // 권한이 이미 허용된 상태라면 수집을 다시 시작하지 않는다.
-            if (_uiState.value is ClusteringUiState.WithClusters) return
-            if (clusterCollectJob != null) return
-
-            refreshClusters()
+    /**
+     * 권한 변경 결과를 반영해 UI 상태와 스트림 수집을 갱신한다.
+     *
+     * @param hasPermission 권한 허용 여부
+     */
+    fun onPermissionChanged(hasPermission: Boolean) {
+        if (!hasPermission) {
+            clusterCollectJob?.cancel()
+            clusterCollectJob = null
+            _uiState.value = ClusteringUiState.PermissionDenied
+            return
         }
 
-        /**
-         * 클러스터 스트림 수집을 수집하고 상태를 갱신한다.
-         */
-        private fun refreshClusters() {
-            clusterCollectJob = viewModelScope.launch {
-                try {
-                    _uiState.value = ClusteringUiState.Loading(emptyList())
+        // 권한이 이미 허용된 상태라면 수집을 다시 시작하지 않는다.
+        if (_uiState.value is ClusteringUiState.WithClusters) return
+        if (clusterCollectJob != null) return
 
-                    // 클러스터 스트림을 수집하며 로딩 상태에 누적한다.
-                    getClusteredMediaStreamUseCase().collect { cluster ->
-                        val updatedClusters = currentClusters() + cluster.toUiModel()
-                        _uiState.value = ClusteringUiState.Loading(updatedClusters)
-                    }
-
-                    // 클러스터링이 완료 되면 Completed 상태로 변경
-                    _uiState.value = ClusteringUiState.Completed(currentClusters())
-                } finally {
-                    clusterCollectJob = null
-                }
-            }
-        }
-
-        /**
-         * 현재 UI 상태에 포함된 클러스터 목록을 가져온다.
-         */
-        private fun currentClusters(): List<ClusterUiModel> =
-            when (val state = _uiState.value) {
-                is ClusteringUiState.WithClusters -> state.clusters
-                ClusteringUiState.PermissionChecking,
-                ClusteringUiState.PermissionDenied -> emptyList()
-            }
+        refreshClusters()
     }
+
+    /**
+     * 클러스터 스트림 수집을 수집하고 상태를 갱신한다.
+     */
+    private fun refreshClusters() {
+        clusterCollectJob = viewModelScope.launch {
+            try {
+                _uiState.value = ClusteringUiState.Loading(emptyList())
+
+                // 클러스터 스트림을 수집하며 로딩 상태에 누적한다.
+                getClusteredMediaStreamUseCase().collect { cluster ->
+                    val updatedClusters = currentClusters() + cluster.toUiModel()
+                    _uiState.value = ClusteringUiState.Loading(updatedClusters)
+                }
+
+                // 클러스터링이 완료 되면 Completed 상태로 변경
+                _uiState.value = ClusteringUiState.Completed(currentClusters())
+            } finally {
+                clusterCollectJob = null
+            }
+        }
+    }
+
+    /**
+     * 현재 UI 상태에 포함된 클러스터 목록을 가져온다.
+     */
+    private fun currentClusters(): List<ClusterUiModel> = when (val state = _uiState.value) {
+        is ClusteringUiState.WithClusters -> state.clusters
+        ClusteringUiState.PermissionChecking -> emptyList()
+        ClusteringUiState.PermissionDenied -> emptyList()
+    }
+}

--- a/feature/album/src/main/java/com/chac/feature/album/gallery/GalleryViewModel.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/gallery/GalleryViewModel.kt
@@ -17,10 +17,9 @@ class GalleryViewModel(
          *
          * @param photos 갤러리 화면에 표시할 사진 목록
          */
-        fun provideFactory(photos: List<String>): ViewModelProvider.Factory =
-            object : ViewModelProvider.Factory {
-                @Suppress("UNCHECKED_CAST")
-                override fun <T : ViewModel> create(modelClass: Class<T>): T = GalleryViewModel(photos) as T
-            }
+        fun provideFactory(photos: List<String>): ViewModelProvider.Factory = object : ViewModelProvider.Factory {
+            @Suppress("UNCHECKED_CAST")
+            override fun <T : ViewModel> create(modelClass: Class<T>): T = GalleryViewModel(photos) as T
+        }
     }
 }

--- a/feature/album/src/main/java/com/chac/feature/album/model/MediaUiMapper.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/model/MediaUiMapper.kt
@@ -8,10 +8,9 @@ import com.chac.domain.album.media.Media
  * @receiver 변환 대상 도메인 미디어
  * @return 미디어 UI 모델
  */
-internal fun Media.toUiModel(): MediaUiModel =
-    MediaUiModel(
-        id = id,
-        uriString = uriString,
-        dateTaken = dateTaken,
-        mediaType = mediaType,
-    )
+internal fun Media.toUiModel(): MediaUiModel = MediaUiModel(
+    id = id,
+    uriString = uriString,
+    dateTaken = dateTaken,
+    mediaType = mediaType,
+)


### PR DESCRIPTION
## 이 PR의 주요 목적 요약
https://github.com/Nexters/Chac-Android/pull/3 에서 제대로 적용되지 않은 개행 정책 수정과 더불어,
여전히 남아있던 코드 작성시 불편함을 주는 개행 정책을 비활성화하며 프로젝트 전역적으로 코드 포맷을 수정합니다.

## 구현된 주요 기능/변경사항 (bullet points)
- 전반적인 코드베이스에 대해 자동 포매팅(auto-formatting)을 적용했습니다.
- 불필요한 공백을 제거하고, ktlint 컨벤션에 맞게 코드를 정리했습니다.
- `.editorconfig` 파일에 `annotation`, `class-signature`, `function-signature`, `chain-method-continuation` 등의 추가적인 ktlint 규칙 비활성화를 설정하여 코드 스타일을 통일했습니다.

| Annotation과 생성자 개행 제거 |
|-----|
| <img width="1202" height="112" alt="Image" src="https://github.com/user-attachments/assets/be91e24a-6b54-41a9-9e6c-e005e0c923e8" /> |

| (=) 기호 뒤에 개행 제거 |
|-----|
| <img width="1195" height="159" alt="Image" src="https://github.com/user-attachments/assets/f1767559-4d90-421f-88a8-675a26eb9e30" /> |


## 추가 참고사항이나 검토 포인트
- https://github.com/Nexters/Chac-Android/pull/3 작업에서 부족했던 점을 보완하는 PR 입니다.
