### PR TITLE
[#46] (앨범 -> 갤러리)화면 이동시 발생하는 앱의 비정상 종료 문제 수정

### DIFF
--- a/feature/album/src/main/java/com/chac/feature/album/model/SaveUiStatus.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/model/SaveUiStatus.kt
@@ -2,18 +2,23 @@ package com.chac.feature.album.model
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
+import kotlinx.serialization.Serializable
 
 /**
  * 클러스터 저장 상태.
  */
 @Stable
+@Serializable
 sealed interface SaveUiStatus {
     @Immutable
+    @Serializable
     data object Default : SaveUiStatus
 
     @Immutable
+    @Serializable
     data object Saving : SaveUiStatus
 
     @Immutable
+    @Serializable
     data object SaveCompleted : SaveUiStatus
 }


### PR DESCRIPTION
## 이 PR의 주요 목적 요약
직접 현상을 목격하진 못했으나,
테스트 기기를 연결했을 때 아래와 같은 로그가 찍혀있는것이 포착되어 해당 결함을 수정합니다.

## 구현된 주요 기능/변경사항 (bullet points)

앨범 → 갤러리 화면 이동 시 `SaveUiStatus` 직렬화 누락으로 발생하던 앱 크래시를 해결합니다.
  - `SaveUiStatus` 및 하위 객체들에 `@Serializable` 추가하여 폴리모픽 직렬화 오류 방지

## 추가 참고사항이나 검토 포인트

<img width="1947" height="616" alt="image" src="https://github.com/user-attachments/assets/b004b004-22fb-4e15-9886-2038e8563dd5" />

```
 E  FATAL EXCEPTION: main (Fix with AI)
    Process: com.chac.app, PID: 24895
    kotlinx.serialization.SerializationException: Serializer for subclass 'Default' is not found in the polymorphic scope of 'SaveUiStatus'.
    Check if class with serial name 'Default' exists and serializer is registered in a corresponding SerializersModule.
    To be registered automatically, class 'Default' has to be '@Serializable', and the base class 'SaveUiStatus' has to be sealed and '@Serializable'.
    	at kotlinx.serialization.internal.AbstractPolymorphicSerializerKt.throwSubtypeNotRegistered(AbstractPolymorphicSerializer.kt:102)
    	at kotlinx.serialization.internal.AbstractPolymorphicSerializerKt.throwSubtypeNotRegistered(AbstractPolymorphicSerializer.kt:114)
    	at kotlinx.serialization.PolymorphicSerializerKt.findPolymorphicSerializer(PolymorphicSerializer.kt:109)
    	at kotlinx.serialization.internal.AbstractPolymorphicSerializer.serialize(AbstractPolymorphicSerializer.kt:32)
    	at kotlinx.serialization.encoding.Encoder.encodeSerializableValue(Encoding.kt:280)
    	at kotlinx.serialization.encoding.AbstractEncoder.encodeSerializableValue(AbstractEncoder.kt:18)
    	at androidx.savedstate.serialization.SavedStateEncoder.encodeSerializableValue(SavedStateEncoder.kt:301)
    	at kotlinx.serialization.encoding.AbstractEncoder.encodeSerializableElement(AbstractEncoder.kt:80)
    	at com.chac.feature.album.model.MediaClusterUiModel.write$Self$album_debug(MediaClusterUiModel.kt:14)
    	at com.chac.feature.album.model.MediaClusterUiModel$$serializer.serialize(MediaClusterUiModel.kt:14)
    	at com.chac.feature.album.model.MediaClusterUiModel$$serializer.serialize(MediaClusterUiModel.kt:14)
    	at kotlinx.serialization.encoding.Encoder.encodeSerializableValue(Encoding.kt:280)
    	at kotlinx.serialization.encoding.AbstractEncoder.encodeSerializableValue(AbstractEncoder.kt:18)
    	at androidx.savedstate.serialization.SavedStateEncoder.encodeSerializableValue(SavedStateEncoder.kt:301)
    	at kotlinx.serialization.encoding.AbstractEncoder.encodeSerializableElement(AbstractEncoder.kt:80)
    	at com.chac.feature.album.navigation.AlbumNavKey$Gallery.write$Self$album_debug(AlbumNavKey.kt:19)
    	at com.chac.feature.album.navigation.AlbumNavKey$Gallery$$serializer.serialize(AlbumNavKey.kt:19)
    	at com.chac.feature.album.navigation.AlbumNavKey$Gallery$$serializer.serialize(AlbumNavKey.kt:19)
    	at kotlinx.serialization.encoding.Encoder.encodeSerializableValue(Encoding.kt:280)
    	at kotlinx.serialization.encoding.AbstractEncoder.encodeSerializableValue(AbstractEncoder.kt:18)
    	at androidx.savedstate.serialization.SavedStateEncoder.encodeSerializableValue(SavedStateEncoder.kt:301)
    	at kotlinx.serialization.encoding.AbstractEncoder.encodeSerializableElement(AbstractEncoder.kt:80)
    	at androidx.navigation3.runtime.serialization.NavKeySerializer.serialize(NavKeySerializer.android.kt:94)
    	at androidx.navigation3.runtime.serialization.NavKeySerializer.serialize(NavKeySerializer.android.kt:54)
    	at kotlinx.serialization.encoding.Encoder.encodeSerializableValue(Encoding.kt:280)
    	at kotlinx.serialization.encoding.AbstractEncoder.encodeSerializableValue(AbstractEncoder.kt:18)
    	at androidx.savedstate.serialization.SavedStateEncoder.encodeSerializableValue(SavedStateEncoder.kt:301)
    	at kotlinx.serialization.encoding.AbstractEncoder.encodeSerializableElement(AbstractEncoder.kt:80)
    	at kotlinx.serialization.internal.CollectionLikeSerializer.serialize(CollectionSerializers.kt:69)
    	at kotlinx.serialization.encoding.Encoder.encodeSerializableValue(Encoding.kt:280)
    	at kotlinx.serialization.encoding.AbstractEncoder.encodeSerializableValue(AbstractEncoder.kt:18)
    	at androidx.savedstate.serialization.SavedStateEncoder.encodeSerializableValue(SavedStateEncoder.kt:301)
    	at androidx.savedstate.compose.serialization.serializers.SnapshotStateListSerializer.serialize(SnapshotStateListSerializer.kt:62)
    	at androidx.savedstate.compose.serialization.serializers.SnapshotStateListSerializer.serialize(SnapshotStateListSerializer.kt:52)
```