### PR TITLE
[#50] 상태바 및 네비게이션바 색상 변경

### DIFF
--- a/app/src/main/java/com/chac/MainActivity.kt
+++ b/app/src/main/java/com/chac/MainActivity.kt
@@ -2,12 +2,15 @@ package com.chac
 
 import android.os.Bundle
 import androidx.activity.ComponentActivity
+import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.tooling.preview.Preview
+import com.chac.core.designsystem.ui.theme.ChacColors
 import com.chac.core.designsystem.ui.theme.ChacTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -15,7 +18,10 @@ import dagger.hilt.android.AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+        enableEdgeToEdge(
+            statusBarStyle = SystemBarStyle.dark(ChacColors.Background.toArgb()),
+            navigationBarStyle = SystemBarStyle.dark(ChacColors.Background.toArgb()),
+        )
         setContent {
             ChacTheme {
                 ChacAppNavigation()


### PR DESCRIPTION
## 이 PR의 주요 목적 요약
- `enableEdgeToEdge()` 를 활용하여 StatusBar와 BottomNavigation에 디자인과 같은 배경색을 적용합니다.

## 구현된 주요 기능/변경사항 (bullet points)

| AS-IS | TO-BE |
|-----|-----|
| <img width="350" alt="Image" src="https://github.com/user-attachments/assets/9ae4c20d-943b-4470-a6b7-6990648a561b" /> | <img width="350" alt="Image" src="https://github.com/user-attachments/assets/c2d51d98-d994-4775-93de-9fabf94a7385" /> |

## 추가 참고사항이나 검토 포인트
- 아래 PR이 병합 된 후 순차적으로 병합 할 예정 입니다.
  - https://github.com/Nexters/Chac-Android/pull/48
  - https://github.com/Nexters/Chac-Android/pull/49 
