### PR TITLE
[#56] 카메라, 다운로드, 카카오톡 폴더 사진만 클러스터링 대상으로 필터링

### DIFF
--- a/data/album/src/main/java/com/chac/data/album/media/MediaDataSource.kt
+++ b/data/album/src/main/java/com/chac/data/album/media/MediaDataSource.kt
@@ -35,6 +35,7 @@ internal class MediaDataSource @Inject constructor(
             MediaStore.Files.FileColumns._ID,
             MediaStore.Files.FileColumns.DATE_TAKEN,
             MediaStore.Files.FileColumns.MEDIA_TYPE,
+            MediaStore.Files.FileColumns.DATA,
         )
 
         // 미디어 타입 필터 설정
@@ -52,8 +53,14 @@ internal class MediaDataSource @Inject constructor(
             "${MediaStore.Files.FileColumns.DATE_TAKEN} >= ? AND " +
             "${MediaStore.Files.FileColumns.DATE_TAKEN} <= ?"
 
+        // 폴더 필터 설정 - DCIM, 다운로드, 카카오톡 폴더만 허용
+        // Pictures 폴더는 이미 정리된 앨범들이 저장되므로 제외 (KakaoTalk 제외)
+        val folderSelection = "(${MediaStore.Files.FileColumns.DATA} LIKE '%/DCIM/%' OR " +
+            "${MediaStore.Files.FileColumns.DATA} LIKE '%/Download/%' OR " +
+            "${MediaStore.Files.FileColumns.DATA} LIKE '%/KakaoTalk/%')"
+
         // 최종 쿼리 조건 구성
-        val selection = "$typeSelection AND $timeSelection"
+        val selection = "$typeSelection AND $timeSelection AND $folderSelection"
         val selectionArgs = arrayOf(startTime.toString(), endTime.toString())
 
         // 정렬 설정


### PR DESCRIPTION
## Summary
클러스터링할 사진을 특정 폴더(카메라, 다운로드, 카카오톡)의 사진만 가져오도록 필터링합니다.

### 주요 변경사항
- MediaDataSource.getMedia()에 폴더 경로 필터링 추가
- DATA 컬럼을 projection에 포함
- 다음 폴더의 사진만 클러스터링 대상으로 허용:
  - `/DCIM/Camera/` - 카메라로 촬영한 사진
  - `/Download/` - 다운로드한 사진
  - `/Pictures/KakaoTalk/` 또는 `/KakaoTalk/` - 카카오톡에서 받은 사진
- 이미 정리된 폴더 (Pictures/앨범명 등)의 사진은 제외

### 변경된 파일
- `data/album/media/MediaDataSource.kt` - getMedia() 쿼리에 폴더 필터 추가

### 기대 효과
- 일반적인 사용 케이스의 사진만 클러스터링
- 이미 정리된 앨범의 사진은 다시 클러스터링하지 않음
- 불필요한 사진(스크린샷, 앱 생성 이미지 등) 제외

## Test plan
- [ ] 카메라로 찍은 사진이 클러스터링되는지 확인
- [ ] 다운로드한 사진이 클러스터링되는지 확인
- [ ] 카카오톡에서 받은 사진이 클러스터링되는지 확인
- [ ] 이미 정리된 앨범의 사진은 클러스터링에서 제외되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)