### PR TITLE
[#55] 클러스터 목록 화면에서 로딩이 완료되면 스크롤 포지션이 초기화 되는 문제 해결

### DIFF
--- a/feature/album/src/main/java/com/chac/feature/album/clustering/ClusteringScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/clustering/ClusteringScreen.kt
@@ -144,33 +144,21 @@ private fun ClusteringScreen(
                     PermissionRequiredState { moveToPermissionSetting(context) }
                 }
 
-                is ClusteringUiState.Loading -> {
+                is ClusteringUiState.WithClusters -> {
+                    val isGenerating = uiState is ClusteringUiState.Loading
+
                     CommonSectionOfPermissionGranted(
-                        isGenerating = true,
+                        isGenerating = isGenerating,
                         clusters = clusters,
                     )
 
                     Box(Modifier.weight(1f)) {
                         if (clusters.isEmpty()) {
-                            LoadingState()
-                        } else {
-                            ClusterList(
-                                clusters = clusters,
-                                onClickCluster = onClickCluster,
-                            )
-                        }
-                    }
-                }
-
-                is ClusteringUiState.Completed -> {
-                    CommonSectionOfPermissionGranted(
-                        isGenerating = false,
-                        clusters = clusters,
-                    )
-
-                    Box(Modifier.weight(1f)) {
-                        if (clusters.isEmpty()) {
-                            EmptyState()
+                            if (isGenerating) {
+                                LoadingState()
+                            } else {
+                                EmptyState()
+                            }
                         } else {
                             ClusterList(
                                 clusters = clusters,


### PR DESCRIPTION
## 이 PR의 주요 목적 요약
클러스터 목록 화면에서 로딩이 완료되면 스크롤 포지션이 초기화 되는 문제를 해결합니다.

## 구현된 주요 기능/변경사항 (bullet points)

| 수정 전 | 수정 후 |
|-------|-------|
| <video src="https://github.com/user-attachments/assets/2dac9c84-8585-400c-b6f0-94846ffa3ba0"/> | <video src="https://github.com/user-attachments/assets/32da02a8-a3f6-41f7-ac5c-75e1e5ceb118"/> |

- 클러스터 목록 로딩 완료 후 스크롤 포지션 초기화 이슈 해결 반영

## 추가 참고사항이나 검토 포인트
- 