### PR TITLE
[#28] 갤러리 롱클릭 전체화면 이미지 미리보기

### DIFF
--- a/app/src/main/java/com/chac/AppNavigation.kt
+++ b/app/src/main/java/com/chac/AppNavigation.kt
@@ -46,6 +46,9 @@ fun ChacAppNavigation() {
                     onClickCluster = { cluster ->
                         backStack.add(AlbumNavKey.Gallery(cluster))
                     },
+                    onClickMediaPreview = { cluster, mediaId ->
+                        backStack.add(AlbumNavKey.MediaPreview(cluster, mediaId))
+                    },
                     onSaveCompleted = { title, savedCount ->
                         backStack.add(AlbumNavKey.SaveCompleted(title, savedCount))
                     },

--- a/feature/album/src/main/java/com/chac/feature/album/gallery/component/MediaPreviewScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/gallery/component/MediaPreviewScreen.kt
@@ -1,0 +1,197 @@
+package com.chac.feature.album.gallery.component
+
+import android.text.format.DateUtils
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.chac.core.designsystem.ui.component.ChacImage
+import com.chac.core.designsystem.ui.icon.ChacIcons
+import com.chac.core.designsystem.ui.icon.Close
+import com.chac.core.designsystem.ui.theme.ChacColors
+import com.chac.core.designsystem.ui.theme.ChacTextStyles
+import com.chac.core.designsystem.ui.theme.ChacTheme
+import com.chac.domain.album.media.model.MediaType
+import com.chac.feature.album.model.MediaClusterUiModel
+import com.chac.feature.album.model.MediaUiModel
+
+/**
+ * 미디어 미리보기 화면 라우트
+ *
+ * @param cluster 클러스터
+ * @param mediaId 최초 표시할 미디어 식별자
+ * @param viewModel 미리보기 화면 뷰모델
+ * @param onDismiss 닫기 콜백
+ */
+@Composable
+fun MediaPreviewRoute(
+    cluster: MediaClusterUiModel,
+    mediaId: Long,
+    viewModel: MediaPreviewViewModel = hiltViewModel(),
+    onDismiss: () -> Unit,
+) {
+    LaunchedEffect(viewModel) {
+        viewModel.initialize(cluster, mediaId)
+    }
+
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    when (val state = uiState) {
+        is MediaPreviewUiState.Loading -> {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(ChacColors.Background),
+                contentAlignment = Alignment.Center,
+            ) {
+                CircularProgressIndicator(color = ChacColors.Primary)
+            }
+        }
+
+        is MediaPreviewUiState.Ready -> {
+            MediaPreviewScreen(
+                mediaList = state.mediaList,
+                initialIndex = state.initialIndex,
+                address = state.address,
+                onDismiss = onDismiss,
+            )
+        }
+    }
+}
+
+/**
+ * 전체화면 이미지 미리보기 화면
+ *
+ * 갤러리에서 사진 롱클릭 시 표시되며, 좌우 스와이프로 같은 클러스터 내 다른 사진으로 이동할 수 있다.
+ *
+ * @param mediaList 클러스터 내 미디어 목록
+ * @param initialIndex 최초 표시할 미디어 인덱스
+ * @param address 클러스터 주소
+ * @param onDismiss 닫기 콜백
+ */
+@Composable
+private fun MediaPreviewScreen(
+    mediaList: List<MediaUiModel>,
+    initialIndex: Int,
+    address: String,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    val pagerState = rememberPagerState(
+        initialPage = initialIndex,
+        pageCount = { mediaList.size },
+    )
+
+    val currentMedia by remember {
+        derivedStateOf { mediaList[pagerState.currentPage] }
+    }
+
+    BackHandler(onBack = onDismiss)
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(ChacColors.Background),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .heightIn(min = 52.dp)
+                .padding(start = 20.dp, end = 4.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = address,
+                    style = ChacTextStyles.SubTitle03,
+                    color = ChacColors.Text02,
+                )
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = DateUtils.formatDateTime(
+                        context,
+                        currentMedia.dateTaken,
+                        DateUtils.FORMAT_SHOW_DATE or DateUtils.FORMAT_SHOW_TIME,
+                    ),
+                    style = ChacTextStyles.Caption,
+                    color = ChacColors.Text04Caption,
+                )
+            }
+            IconButton(onClick = onDismiss) {
+                Icon(
+                    imageVector = ChacIcons.Close,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                    tint = ChacColors.Text01,
+                )
+            }
+        }
+
+        HorizontalPager(
+            state = pagerState,
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f),
+        ) { page ->
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                ChacImage(
+                    model = mediaList[page].uriString,
+                    modifier = Modifier.fillMaxSize(),
+                    contentScale = ContentScale.Fit,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.padding(bottom = 20.dp))
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun MediaPreviewScreenPreview() {
+    ChacTheme {
+        MediaPreviewScreen(
+            mediaList = List(10) { index ->
+                MediaUiModel(
+                    id = index.toLong(),
+                    uriString = "content://sample/$index",
+                    dateTaken = 1_700_000_000_000L,
+                    mediaType = MediaType.IMAGE,
+                )
+            },
+            initialIndex = 0,
+            address = "제주특별자치도 제주시",
+            onDismiss = {},
+        )
+    }
+}

--- a/feature/album/src/main/java/com/chac/feature/album/gallery/component/MediaPreviewViewModel.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/gallery/component/MediaPreviewViewModel.kt
@@ -1,0 +1,48 @@
+package com.chac.feature.album.gallery.component
+
+import androidx.lifecycle.ViewModel
+import com.chac.feature.album.model.MediaClusterUiModel
+import com.chac.feature.album.model.MediaUiModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+
+/** 미디어 미리보기 화면 상태를 제공하는 ViewModel */
+@HiltViewModel
+class MediaPreviewViewModel @Inject constructor() : ViewModel() {
+    private val _uiState = MutableStateFlow<MediaPreviewUiState>(MediaPreviewUiState.Loading)
+    val uiState: StateFlow<MediaPreviewUiState> = _uiState.asStateFlow()
+
+    /**
+     * 클러스터와 미디어 ID로 미리보기 상태를 초기화한다.
+     *
+     * @param cluster 클러스터
+     * @param mediaId 최초 표시할 미디어 식별자
+     */
+    fun initialize(cluster: MediaClusterUiModel, mediaId: Long) {
+        if (_uiState.value is MediaPreviewUiState.Ready) return
+
+        val initialIndex = cluster.mediaList
+            .indexOfFirst { it.id == mediaId }
+            .coerceAtLeast(0)
+
+        _uiState.value = MediaPreviewUiState.Ready(
+            mediaList = cluster.mediaList,
+            initialIndex = initialIndex,
+            address = cluster.address,
+        )
+    }
+}
+
+/** 미디어 미리보기 화면 UI 상태 */
+sealed interface MediaPreviewUiState {
+    data object Loading : MediaPreviewUiState
+
+    data class Ready(
+        val mediaList: List<MediaUiModel>,
+        val initialIndex: Int,
+        val address: String,
+    ) : MediaPreviewUiState
+}

--- a/feature/album/src/main/java/com/chac/feature/album/navigation/AlbumEntries.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/navigation/AlbumEntries.kt
@@ -4,6 +4,7 @@ import androidx.navigation3.runtime.EntryProviderScope
 import androidx.navigation3.runtime.NavKey
 import com.chac.feature.album.clustering.ClusteringRoute
 import com.chac.feature.album.gallery.GalleryRoute
+import com.chac.feature.album.gallery.component.MediaPreviewRoute
 import com.chac.feature.album.model.MediaClusterUiModel
 import com.chac.feature.album.save.SaveCompletedRoute
 
@@ -11,6 +12,7 @@ import com.chac.feature.album.save.SaveCompletedRoute
  * 앨범 목적지를 Navigation3 entry provider에 등록한다
  *
  * @param onClickCluster 클러스터 카드 클릭 이벤트 콜백
+ * @param onClickMediaPreview 미디어 미리보기 화면 이동 콜백
  * @param onSaveCompleted 저장 완료 이후 동작을 전달하는 콜백
  * @param onCloseSaveCompleted 저장 완료 화면 닫기 버튼 클릭 이벤트 콜백
  * @param onClickToList 저장 완료 화면에서 '목록으로' 버튼 클릭 이벤트 콜백
@@ -18,6 +20,7 @@ import com.chac.feature.album.save.SaveCompletedRoute
  */
 fun EntryProviderScope<NavKey>.albumEntries(
     onClickCluster: (MediaClusterUiModel) -> Unit,
+    onClickMediaPreview: (MediaClusterUiModel, Long) -> Unit,
     onSaveCompleted: (String, Int) -> Unit,
     onCloseSaveCompleted: () -> Unit,
     onClickToList: () -> Unit,
@@ -32,7 +35,15 @@ fun EntryProviderScope<NavKey>.albumEntries(
         GalleryRoute(
             cluster = key.cluster,
             onSaveCompleted = onSaveCompleted,
+            onClickMediaPreview = onClickMediaPreview,
             onClickBack = onClickBack,
+        )
+    }
+    entry<AlbumNavKey.MediaPreview> { key ->
+        MediaPreviewRoute(
+            cluster = key.cluster,
+            mediaId = key.mediaId,
+            onDismiss = onClickBack,
         )
     }
     entry<AlbumNavKey.SaveCompleted> { key ->

--- a/feature/album/src/main/java/com/chac/feature/album/navigation/AlbumNavKey.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/navigation/AlbumNavKey.kt
@@ -21,6 +21,20 @@ sealed interface AlbumNavKey : NavKey {
         val cluster: MediaClusterUiModel,
     ) : AlbumNavKey
 
+    // TODO: Gallery와 함께 cluster 대신 clusterId로 조회하는 방식으로 전환
+
+    /**
+     * 미디어 미리보기 화면
+     *
+     * @param cluster 클러스터
+     * @param mediaId 최초 표시할 미디어 식별자
+     */
+    @Serializable
+    data class MediaPreview(
+        val cluster: MediaClusterUiModel,
+        val mediaId: Long,
+    ) : AlbumNavKey
+
     /**
      * 앨범 저장 완료 화면
      *


### PR DESCRIPTION
## Summary
- 갤러리 사진 롱클릭 시 전체화면 이미지 뷰어 화면으로 네비게이션
- HorizontalPager로 같은 클러스터 내 사진 좌우 스와이프 지원
- 상단 주소/날짜시간 표시, 페이지 변경 시 날짜시간 갱신
- MediaPreviewViewModel + MediaPreviewRoute/Screen 구조
- TODO: Gallery와 함께 cluster 대신 clusterId로 조회하는 방식으로 전환

## Test plan
- [ ] 갤러리에서 사진 롱클릭 시 전체화면 미리보기 진입 확인
- [ ] 좌우 스와이프로 다른 사진 이동 확인
- [ ] 상단 날짜시간이 현재 사진에 맞게 갱신되는지 확인
- [ ] X 버튼 및 뒤로가기로 갤러리 복귀 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)