### PR TITLE
[#62] 설정화면 와이어프레임 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.chac.android.application)
     alias(libs.plugins.chac.android.compose)
     alias(libs.plugins.chac.android.hilt)
+    alias(libs.plugins.oss.licenses)
 }
 
 android {
@@ -54,4 +55,7 @@ dependencies {
     // Hilt work
     implementation(libs.hilt.ext.work)
     ksp(libs.hilt.ext.compiler)
+
+    // OSS Licenses
+    implementation(libs.play.services.oss.licenses)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,6 +35,13 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesMenuActivity"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+        <activity
+            android:name="com.google.android.gms.oss.licenses.OssLicensesActivity"
+            android:theme="@style/Theme.AppCompat.Light.NoActionBar" />
+
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"

--- a/app/src/main/java/com/chac/AppNavigation.kt
+++ b/app/src/main/java/com/chac/AppNavigation.kt
@@ -49,6 +49,9 @@ fun ChacAppNavigation() {
                     onClickMediaPreview = { cluster, mediaId ->
                         backStack.add(AlbumNavKey.MediaPreview(cluster, mediaId))
                     },
+                    onClickSettings = {
+                        backStack.add(AlbumNavKey.Settings)
+                    },
                     onSaveCompleted = { title, savedCount ->
                         backStack.add(AlbumNavKey.SaveCompleted(title, savedCount))
                     },

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.kotlin.serialization) apply false
+    alias(libs.plugins.oss.licenses) apply false
     alias(libs.plugins.gradle.ktlint)
 }
 

--- a/core/resources/src/main/res/values/strings.xml
+++ b/core/resources/src/main/res/values/strings.xml
@@ -31,4 +31,8 @@
     <string name="save_completed_message">총 %1$d장의 사진이 포함된 앨범을\n갤러리에 저장했어요.</string>
     <string name="save_completed_main_button_title">메인으로</string>
     <string name="save_completed_close_cd">저장 완료 닫기</string>
+    <string name="settings_title">설정</string>
+    <string name="settings_back_cd">뒤로가기</string>
+    <string name="settings_oss_licenses">오픈소스 라이선스</string>
+    <string name="settings_privacy_policy">개인정보 처리방침</string>
 </resources>

--- a/feature/album/build.gradle.kts
+++ b/feature/album/build.gradle.kts
@@ -20,6 +20,9 @@ dependencies {
     implementation(libs.androidx.lifecycle.viewmodel.compose)
     implementation(libs.kotlinx.serialization.json)
 
+    // OSS Licenses
+    implementation(libs.play.services.oss.licenses)
+
     testImplementation(libs.junit)
     testImplementation(libs.kotlinx.serialization.json)
 }

--- a/feature/album/src/main/java/com/chac/feature/album/clustering/ClusteringScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/clustering/ClusteringScreen.kt
@@ -58,11 +58,13 @@ import com.chac.feature.album.model.MediaUiModel
  *
  * @param viewModel 클러스터링 화면 ViewModel
  * @param onClickCluster 클러스터 카드 클릭 이벤트 콜백
+ * @param onClickSettings 설정 버튼 클릭 이벤트 콜백
  */
 @Composable
 fun ClusteringRoute(
     viewModel: ClusteringViewModel = hiltViewModel(),
     onClickCluster: (MediaClusterUiModel) -> Unit,
+    onClickSettings: () -> Unit,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
@@ -105,6 +107,7 @@ fun ClusteringRoute(
     ClusteringScreen(
         uiState = uiState,
         onClickCluster = onClickCluster,
+        onClickSettings = onClickSettings,
     )
 }
 
@@ -113,11 +116,13 @@ fun ClusteringRoute(
  *
  * @param uiState 클러스터링 화면 상태
  * @param onClickCluster 클러스터 카드 클릭 이벤트 콜백
+ * @param onClickSettings 설정 버튼 클릭 이벤트 콜백
  */
 @Composable
 private fun ClusteringScreen(
     uiState: ClusteringUiState,
     onClickCluster: (MediaClusterUiModel) -> Unit,
+    onClickSettings: () -> Unit = {},
 ) {
     val context = LocalContext.current
     val clusters = (uiState as? ClusteringUiState.WithClusters)?.clusters.orEmpty()
@@ -128,7 +133,7 @@ private fun ClusteringScreen(
             .background(ChacColors.Background)
             .padding(horizontal = 20.dp),
     ) {
-        ClusteringTopBar()
+        ClusteringTopBar(onClickSettings = onClickSettings)
 
         Column(
             modifier = Modifier

--- a/feature/album/src/main/java/com/chac/feature/album/navigation/AlbumEntries.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/navigation/AlbumEntries.kt
@@ -7,12 +7,14 @@ import com.chac.feature.album.gallery.GalleryRoute
 import com.chac.feature.album.gallery.component.MediaPreviewRoute
 import com.chac.feature.album.model.MediaClusterUiModel
 import com.chac.feature.album.save.SaveCompletedRoute
+import com.chac.feature.album.settings.SettingsRoute
 
 /**
  * 앨범 목적지를 Navigation3 entry provider에 등록한다
  *
  * @param onClickCluster 클러스터 카드 클릭 이벤트 콜백
  * @param onClickMediaPreview 미디어 미리보기 화면 이동 콜백
+ * @param onClickSettings 설정 화면 이동 콜백
  * @param onSaveCompleted 저장 완료 이후 동작을 전달하는 콜백
  * @param onCloseSaveCompleted 저장 완료 화면 닫기 버튼 클릭 이벤트 콜백
  * @param onClickToList 저장 완료 화면에서 '목록으로' 버튼 클릭 이벤트 콜백
@@ -21,6 +23,7 @@ import com.chac.feature.album.save.SaveCompletedRoute
 fun EntryProviderScope<NavKey>.albumEntries(
     onClickCluster: (MediaClusterUiModel) -> Unit,
     onClickMediaPreview: (MediaClusterUiModel, Long) -> Unit,
+    onClickSettings: () -> Unit,
     onSaveCompleted: (String, Int) -> Unit,
     onCloseSaveCompleted: () -> Unit,
     onClickToList: () -> Unit,
@@ -29,6 +32,7 @@ fun EntryProviderScope<NavKey>.albumEntries(
     entry(AlbumNavKey.Clustering) { _ ->
         ClusteringRoute(
             onClickCluster = onClickCluster,
+            onClickSettings = onClickSettings,
         )
     }
     entry<AlbumNavKey.Gallery> { key ->
@@ -52,6 +56,11 @@ fun EntryProviderScope<NavKey>.albumEntries(
             savedCount = key.savedCount,
             onClose = onCloseSaveCompleted,
             onClickToList = onClickToList,
+        )
+    }
+    entry(AlbumNavKey.Settings) { _ ->
+        SettingsRoute(
+            onClickBack = onClickBack,
         )
     }
 }

--- a/feature/album/src/main/java/com/chac/feature/album/navigation/AlbumNavKey.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/navigation/AlbumNavKey.kt
@@ -46,4 +46,8 @@ sealed interface AlbumNavKey : NavKey {
         val title: String,
         val savedCount: Int,
     ) : AlbumNavKey
+
+    /** 설정 화면 */
+    @Serializable
+    data object Settings : AlbumNavKey
 }

--- a/feature/album/src/main/java/com/chac/feature/album/settings/SettingsScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/settings/SettingsScreen.kt
@@ -1,0 +1,165 @@
+package com.chac.feature.album.settings
+
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.chac.core.designsystem.ui.icon.Back
+import com.chac.core.designsystem.ui.icon.ChacIcons
+import com.chac.core.designsystem.ui.theme.ChacColors
+import com.chac.core.designsystem.ui.theme.ChacTextStyles
+import com.chac.core.designsystem.ui.theme.ChacTheme
+import com.chac.core.resources.R
+import com.google.android.gms.oss.licenses.OssLicensesMenuActivity
+
+private const val PRIVACY_POLICY_URL =
+    "https://ojh102.notion.site/2ed107af0aeb80608ec3c5550dca41eb?pvs=74"
+
+/**
+ * 설정 화면 라우트
+ *
+ * @param onClickBack 뒤로가기 버튼 클릭 이벤트 콜백
+ */
+@Composable
+fun SettingsRoute(
+    onClickBack: () -> Unit,
+) {
+    val context = LocalContext.current
+
+    SettingsScreen(
+        onClickBack = onClickBack,
+        onClickOssLicenses = {
+            context.startActivity(Intent(context, OssLicensesMenuActivity::class.java))
+        },
+        onClickPrivacyPolicy = {
+            context.startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(PRIVACY_POLICY_URL)))
+        },
+    )
+}
+
+/**
+ * 설정 화면
+ *
+ * @param onClickBack 뒤로가기 버튼 클릭 이벤트 콜백
+ * @param onClickOssLicenses 오픈소스 라이선스 클릭 이벤트 콜백
+ * @param onClickPrivacyPolicy 개인정보 처리방침 클릭 이벤트 콜백
+ */
+@Composable
+private fun SettingsScreen(
+    onClickBack: () -> Unit,
+    onClickOssLicenses: () -> Unit,
+    onClickPrivacyPolicy: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(ChacColors.Background),
+    ) {
+        SettingsTopBar(onClickBack = onClickBack)
+
+        SettingsItem(
+            title = stringResource(R.string.settings_oss_licenses),
+            onClick = onClickOssLicenses,
+        )
+
+        SettingsItem(
+            title = stringResource(R.string.settings_privacy_policy),
+            onClick = onClickPrivacyPolicy,
+        )
+    }
+}
+
+/**
+ * 설정 화면 TopBar
+ *
+ * @param onClickBack 뒤로가기 버튼 클릭 이벤트 콜백
+ */
+@Composable
+private fun SettingsTopBar(
+    onClickBack: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .heightIn(52.dp)
+            .padding(horizontal = 4.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        IconButton(
+            onClick = onClickBack,
+            modifier = Modifier.align(Alignment.CenterStart),
+        ) {
+            Icon(
+                imageVector = ChacIcons.Back,
+                contentDescription = stringResource(R.string.settings_back_cd),
+                tint = ChacColors.Text01,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+        Text(
+            text = stringResource(R.string.settings_title),
+            style = ChacTextStyles.Title,
+            color = ChacColors.Text01,
+        )
+    }
+}
+
+/**
+ * 설정 항목
+ *
+ * @param title 항목 제목
+ * @param onClick 클릭 이벤트 콜백
+ */
+@Composable
+private fun SettingsItem(
+    title: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(horizontal = 20.dp, vertical = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = ChacTextStyles.Body,
+            color = ChacColors.Text01,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SettingsScreenPreview() {
+    ChacTheme {
+        SettingsScreen(
+            onClickBack = {},
+            onClickOssLicenses = {},
+            onClickPrivacyPolicy = {},
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,10 @@ room = "2.8.4"
 # Lint & Formatting
 ktlint = "14.0.1"
 
+# Google Play Services
+ossLicensesPlugin = "0.10.10"
+playServicesOssLicenses = "17.4.0"
+
 # ETC
 apacheCommonsMath3 = "3.6.1"
 timber = "5.0.1"
@@ -102,6 +106,9 @@ room-compiler = { group = "androidx.room", name = "room-compiler", version.ref =
 # Unit Test
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 
+# Google Play Services
+play-services-oss-licenses = { group = "com.google.android.gms", name = "play-services-oss-licenses", version.ref = "playServicesOssLicenses" }
+
 # ETC
 commons-math3 = { group = "org.apache.commons", name = "commons-math3", version.ref = "apacheCommonsMath3" }
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timber" }
@@ -117,6 +124,7 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 gradle-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+oss-licenses = { id = "com.google.android.gms.oss-licenses-plugin", version.ref = "ossLicensesPlugin" }
 
 # Custom Plugins
 chac-android-application = { id = "chac.android.application" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,6 +11,13 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
     }
+    resolutionStrategy {
+        eachPlugin {
+            if (requested.id.id == "com.google.android.gms.oss-licenses-plugin") {
+                useModule("com.google.android.gms:oss-licenses-plugin:${requested.version}")
+            }
+        }
+    }
 }
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)


### PR DESCRIPTION
## Summary
- 클러스터링 화면 설정 아이콘 클릭 시 설정 페이지로 이동하도록 네비게이션 연결
- 설정 화면에 오픈소스 라이선스(Google Play Services OSS Licenses Plugin) 항목 추가
- 설정 화면에 개인정보 처리방침(Notion URL 외부 브라우저) 항목 추가

## Test plan
- [ ] 클러스터링 화면에서 설정 아이콘 클릭 시 설정 화면으로 이동 확인
- [ ] 설정 화면에서 뒤로가기 버튼 동작 확인
- [ ] 오픈소스 라이선스 항목 클릭 시 OssLicensesMenuActivity 정상 표시 확인
- [ ] 개인정보 처리방침 항목 클릭 시 외부 브라우저에서 Notion 페이지 열림 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)