### PR TITLE
[#63] 갤러리 및 클러스터링 화면에 스크롤 페이딩 효과 추가

### DIFF
--- a/core/designsystem/src/main/java/com/chac/core/designsystem/ui/modifier/FadingEdge.kt
+++ b/core/designsystem/src/main/java/com/chac/core/designsystem/ui/modifier/FadingEdge.kt
@@ -1,0 +1,80 @@
+package com.chac.core.designsystem.ui.modifier
+
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.BlendMode
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * 알파 마스크를 이용해 컴포저블 컨텐츠에 상/하단 페이딩 엣지를 적용한다.
+ *
+ * 참고:
+ * - Offscreen compositing + BlendMode.DstIn 으로 알파를 마스킹한다. 페이드 구간은 배경이 비쳐 보인다.
+ * - 스크롤 상태 기반으로 strength(0..1)를 넘기면 페이드가 자연스럽게 변한다.
+ */
+fun Modifier.verticalFadingEdge(
+    top: Dp = 24.dp,
+    bottom: Dp = 24.dp,
+    topStrength: Float = 1f, // 0f = 페이드 없음, 1f = 최대 페이드
+    bottomStrength: Float = 1f, // 0f = 페이드 없음, 1f = 최대 페이드
+): Modifier {
+    val topS = topStrength.coerceIn(0f, 1f)
+    val bottomS = bottomStrength.coerceIn(0f, 1f)
+    if (topS == 0f && bottomS == 0f) return this
+
+    return this
+        // BlendMode.DstIn 마스킹이 정상 동작하도록 offscreen으로 그린다.
+        .graphicsLayer { compositingStrategy = CompositingStrategy.Offscreen }
+        .drawWithContent {
+            drawContent()
+
+            val h = size.height
+            if (h <= 0f) return@drawWithContent
+
+            val topPx = top.toPx().coerceAtLeast(0f)
+            val bottomPx = bottom.toPx().coerceAtLeast(0f)
+
+            // 픽셀을 비율로 변환하고 stop 순서가 꼬이지 않도록 보정한다.
+            val topStop = (topPx / h).coerceIn(0f, 1f)
+            val bottomStart = ((h - bottomPx) / h).coerceIn(0f, 1f)
+            val midTop = minOf(topStop, bottomStart)
+            val midBottom = maxOf(topStop, bottomStart)
+
+            // DstIn은 소스 알파를 마스크로 사용한다 (0 = 완전 투명/클립, 1 = 완전 표시).
+            val startMask = Color.Black.copy(alpha = 1f - topS)
+            val endMask = Color.Black.copy(alpha = 1f - bottomS)
+            val opaque = Color.Black // alpha = 1
+
+            val brush = Brush.verticalGradient(
+                colorStops = arrayOf(
+                    0f to startMask,
+                    midTop to opaque,
+                    midBottom to opaque,
+                    1f to endMask,
+                ),
+            )
+
+            // 기존 컨텐츠를 소스 알파로 마스킹한다.
+            drawRect(
+                brush = brush,
+                blendMode = BlendMode.DstIn,
+            )
+        }
+}
+
+fun Modifier.verticalFadingEdge(
+    top: Dp = 24.dp,
+    bottom: Dp = 24.dp,
+    showTop: Boolean = true,
+    showBottom: Boolean = true,
+): Modifier = verticalFadingEdge(
+    top = top,
+    bottom = bottom,
+    topStrength = if (showTop) 1f else 0f,
+    bottomStrength = if (showBottom) 1f else 0f,
+)

--- a/core/designsystem/src/main/java/com/chac/core/designsystem/ui/modifier/ScrollFadingEdge.kt
+++ b/core/designsystem/src/main/java/com/chac/core/designsystem/ui/modifier/ScrollFadingEdge.kt
@@ -1,0 +1,140 @@
+package com.chac.core.designsystem.ui.modifier
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.grid.LazyGridState
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.composed
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * [LazyListState] 기반 스크롤 영역에 상/하단 페이딩 엣지를 쉽게 적용하기 위한 Modifier.
+ *
+ * 사용 예:
+ * - val state = rememberLazyListState()
+ * - LazyColumn(state = state, modifier = Modifier.verticalScrollFadingEdge(state))
+ *
+ * [ScrollFadingEdgeMode.PaddingReveal] (기본값)에서는 페이드 마스크가 항상 존재한다.
+ * `contentPadding`(top/bottom)으로 여백을 확보하면, 컨텐츠가 그 아래로 스크롤되며
+ * 페이드가 자연스럽게 "드러나는" 느낌이 된다(없다/생기다 방식이 아님).
+ *
+ * 권장:
+ * - `contentPadding`의 top/bottom은 각각 `top`/`bottom` 이상으로 준다.
+ */
+enum class ScrollFadingEdgeMode {
+    /**
+     * 페이드 마스크를 항상 최대 강도로 적용한다.
+     * `contentPadding`과 함께 쓰면 자연스럽다.
+     */
+    PaddingReveal,
+
+    /**
+     * 스크롤 오프셋 및 하단 도달 여부에 따라 페이드 강도를 0..1로 변화시킨다.
+     */
+    ScrollStrength,
+}
+
+fun Modifier.verticalScrollFadingEdge(
+    state: LazyListState,
+    top: Dp = 10.dp,
+    bottom: Dp = 10.dp,
+    mode: ScrollFadingEdgeMode = ScrollFadingEdgeMode.PaddingReveal,
+): Modifier = composed {
+    if (mode == ScrollFadingEdgeMode.PaddingReveal) {
+        return@composed this.verticalFadingEdge(
+            top = top,
+            bottom = bottom,
+            topStrength = 1f,
+            bottomStrength = 1f,
+        )
+    }
+
+    val density = LocalDensity.current
+    val topFadePx = with(density) { top.toPx() }.coerceAtLeast(1f)
+    val bottomFadePx = with(density) { bottom.toPx() }.coerceAtLeast(1f)
+
+    val topStrength by remember(state, topFadePx) {
+        derivedStateOf {
+            if (state.firstVisibleItemIndex > 0) return@derivedStateOf 1f
+            (state.firstVisibleItemScrollOffset / topFadePx).coerceIn(0f, 1f)
+        }
+    }
+    val bottomStrength by remember(state, bottomFadePx) {
+        derivedStateOf {
+            val layoutInfo = state.layoutInfo
+            val total = layoutInfo.totalItemsCount
+            if (total <= 0) return@derivedStateOf 0f
+
+            val last = layoutInfo.visibleItemsInfo.lastOrNull() ?: return@derivedStateOf 0f
+            if (last.index < total - 1) return@derivedStateOf 1f
+
+            val overflowPx = (last.offset + last.size) - layoutInfo.viewportEndOffset
+            if (overflowPx <= 0) 0f else (overflowPx / bottomFadePx).coerceIn(0f, 1f)
+        }
+    }
+
+    this.verticalFadingEdge(
+        top = top,
+        bottom = bottom,
+        topStrength = topStrength,
+        bottomStrength = bottomStrength,
+    )
+}
+
+/**
+ * [LazyGridState] 기반 스크롤 영역에 상/하단 페이딩 엣지를 쉽게 적용하기 위한 Modifier.
+ *
+ * 사용 예:
+ * - val state = rememberLazyGridState()
+ * - LazyVerticalGrid(state = state, modifier = Modifier.verticalScrollFadingEdge(state))
+ */
+fun Modifier.verticalScrollFadingEdge(
+    state: LazyGridState,
+    top: Dp = 10.dp,
+    bottom: Dp = 10.dp,
+    mode: ScrollFadingEdgeMode = ScrollFadingEdgeMode.PaddingReveal,
+): Modifier = composed {
+    if (mode == ScrollFadingEdgeMode.PaddingReveal) {
+        return@composed this.verticalFadingEdge(
+            top = top,
+            bottom = bottom,
+            topStrength = 1f,
+            bottomStrength = 1f,
+        )
+    }
+
+    val density = LocalDensity.current
+    val topFadePx = with(density) { top.toPx() }.coerceAtLeast(1f)
+    val bottomFadePx = with(density) { bottom.toPx() }.coerceAtLeast(1f)
+
+    val topStrength by remember(state, topFadePx) {
+        derivedStateOf {
+            if (state.firstVisibleItemIndex > 0) return@derivedStateOf 1f
+            (state.firstVisibleItemScrollOffset / topFadePx).coerceIn(0f, 1f)
+        }
+    }
+    val bottomStrength by remember(state, bottomFadePx) {
+        derivedStateOf {
+            val layoutInfo = state.layoutInfo
+            val total = layoutInfo.totalItemsCount
+            if (total <= 0) return@derivedStateOf 0f
+
+            val last = layoutInfo.visibleItemsInfo.lastOrNull() ?: return@derivedStateOf 0f
+            if (last.index < total - 1) return@derivedStateOf 1f
+
+            val overflowPx = (last.offset.y + last.size.height) - layoutInfo.viewportEndOffset
+            if (overflowPx <= 0) 0f else (overflowPx / bottomFadePx).coerceIn(0f, 1f)
+        }
+    }
+
+    this.verticalFadingEdge(
+        top = top,
+        bottom = bottom,
+        topStrength = topStrength,
+        bottomStrength = bottomStrength,
+    )
+}

--- a/feature/album/src/main/java/com/chac/feature/album/clustering/ClusteringScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/clustering/ClusteringScreen.kt
@@ -202,7 +202,7 @@ private fun CommonSectionOfPermissionGranted(
             clusterCount = clusters.size,
         )
 
-        Spacer(modifier = Modifier.height(16.dp))
+        Spacer(modifier = Modifier.height(6.dp))
     }
 }
 

--- a/feature/album/src/main/java/com/chac/feature/album/clustering/component/ClusterList.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/clustering/component/ClusterList.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
@@ -33,11 +34,13 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import com.chac.core.designsystem.ui.component.ChacImage
 import com.chac.core.designsystem.ui.icon.ArrowTopRight
 import com.chac.core.designsystem.ui.icon.ChacIcons
+import com.chac.core.designsystem.ui.modifier.verticalScrollFadingEdge
 import com.chac.core.designsystem.ui.theme.ChacColors
 import com.chac.core.designsystem.ui.theme.ChacTextStyles
 import com.chac.core.designsystem.ui.theme.ChacTheme
@@ -57,6 +60,9 @@ import com.chac.feature.album.model.MediaUiModel
 fun ClusterList(
     clusters: List<MediaClusterUiModel>,
     modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(top = 12.dp, bottom = 40.dp),
+    fadingEdgeTop: Dp = 12.dp,
+    fadingEdgeBottom: Dp = 12.dp,
     clusterCardBackgroundColor: (MediaClusterUiModel, Int) -> Color = { _, index ->
         val colors = listOf(
             ChacColors.Primary,
@@ -67,10 +73,20 @@ fun ClusterList(
     },
     onClickCluster: (MediaClusterUiModel) -> Unit,
 ) {
+    val listState = rememberLazyListState()
+
     LazyColumn(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScrollFadingEdge(
+                state = listState,
+                top = fadingEdgeTop,
+                bottom = fadingEdgeBottom,
+            ),
+        state = listState,
         verticalArrangement = Arrangement.spacedBy(14.dp),
-        contentPadding = PaddingValues(bottom = 40.dp),
+        // 규칙: 페이딩 엣지(top/bottom) 높이만큼 contentPadding(top/bottom)을 확보해야 자연스럽다.
+        contentPadding = contentPadding,
     ) {
         itemsIndexed(items = clusters, key = { _, item -> item.id }) { index, cluster ->
             ClusterCard(

--- a/feature/album/src/main/java/com/chac/feature/album/gallery/GalleryScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/gallery/GalleryScreen.kt
@@ -2,10 +2,10 @@ package com.chac.feature.album.gallery
 
 import android.provider.MediaStore
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
@@ -24,6 +24,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -56,6 +57,7 @@ import com.chac.core.designsystem.ui.icon.Back
 import com.chac.core.designsystem.ui.icon.ChacIcons
 import com.chac.core.designsystem.ui.icon.CheckSelected
 import com.chac.core.designsystem.ui.icon.CheckUnselected
+import com.chac.core.designsystem.ui.modifier.verticalScrollFadingEdge
 import com.chac.core.designsystem.ui.theme.ChacColors
 import com.chac.core.designsystem.ui.theme.ChacTextStyles
 import com.chac.core.designsystem.ui.theme.ChacTheme
@@ -145,6 +147,8 @@ private fun GalleryScreen(
     onClickBack: () -> Unit,
 ) {
     var isExitDialogVisible by remember { mutableStateOf(false) }
+    val gridState = rememberLazyGridState()
+
     val cluster = uiState.cluster
     val title = cluster.address.ifBlank {
         cluster.formattedDate.ifBlank { stringResource(R.string.clustering_default_album_title) }
@@ -250,15 +254,21 @@ private fun GalleryScreen(
                     }
                 }
             }
-            Spacer(modifier = Modifier.height(20.dp))
+
             LazyVerticalGrid(
                 columns = GridCells.Fixed(3),
                 modifier = Modifier
                     .weight(1f)
-                    .fillMaxWidth(),
+                    .fillMaxWidth()
+                    .verticalScrollFadingEdge(
+                        state = gridState,
+                        top = 14.dp,
+                        bottom = 14.dp,
+                    ),
+                state = gridState,
                 horizontalArrangement = Arrangement.spacedBy(10.dp),
                 verticalArrangement = Arrangement.spacedBy(10.dp),
-                contentPadding = PaddingValues(horizontal = 20.dp),
+                contentPadding = PaddingValues(14.dp),
             ) {
                 itemsIndexed(mediaList, key = { _, media -> media.id }) { index, media ->
                     GalleryPhotoItem(
@@ -271,7 +281,9 @@ private fun GalleryScreen(
                     )
                 }
             }
-            Spacer(modifier = Modifier.height(20.dp))
+
+            Spacer(modifier = Modifier.height(6.dp))
+
             Button(
                 onClick = onClickSave,
                 enabled = uiState is GalleryUiState.SomeSelected,


### PR DESCRIPTION
## 이 PR의 주요 목적 요약
갤러리 및 클러스터링 화면에 스크롤 페이딩 효과를 추가합니다.

## 구현된 주요 기능/변경사항 (bullet points)
- 갤러리와 클러스터링 목록의 상하단에 스크롤 시 부드럽게 사라지는 페이딩 엣지(fading edge) 효과를 적용했습니다.
- `LazyVerticalGrid`와 `LazyColumn`에 `verticalScrollFadingEdge` Modifier를 사용하여 구현했습니다.

## 추가 참고사항이나 검토 포인트
-
