### PR TITLE
[#72] Firebase Crashlytics 연동

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@ build/
 *.jks
 *.keystore
 
+# Firebase
+google-services.json
+
 # User-specific configurations
 .idea

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,6 +6,8 @@ plugins {
     alias(libs.plugins.chac.android.compose)
     alias(libs.plugins.chac.android.hilt)
     alias(libs.plugins.oss.licenses)
+    alias(libs.plugins.google.services)
+    alias(libs.plugins.firebase.crashlytics)
 }
 
 android {
@@ -55,6 +57,10 @@ dependencies {
     // Hilt work
     implementation(libs.hilt.ext.work)
     ksp(libs.hilt.ext.compiler)
+
+    // Firebase
+    implementation(platform(libs.firebase.bom))
+    implementation(libs.firebase.crashlytics)
 
     // OSS Licenses
     implementation(libs.play.services.oss.licenses)

--- a/app/src/main/java/com/chac/ChacApp.kt
+++ b/app/src/main/java/com/chac/ChacApp.kt
@@ -1,8 +1,10 @@
 package com.chac
 
 import android.app.Application
+import android.util.Log
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import dagger.hilt.android.HiltAndroidApp
 import timber.log.Timber
 import javax.inject.Inject
@@ -21,6 +23,19 @@ class ChacApp : Application(), Configuration.Provider {
         super.onCreate()
         if (BuildConfig.DEBUG) {
             Timber.plant(Timber.DebugTree())
+        } else {
+            Timber.plant(CrashlyticsTree())
+        }
+    }
+
+    private class CrashlyticsTree : Timber.Tree() {
+        override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
+            if (priority == Log.VERBOSE || priority == Log.DEBUG) return
+
+            FirebaseCrashlytics.getInstance().log("${tag ?: "NO_TAG"}: $message")
+            if (t != null) {
+                FirebaseCrashlytics.getInstance().recordException(t)
+            }
         }
     }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
     alias(libs.plugins.hilt) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.oss.licenses) apply false
+    alias(libs.plugins.google.services) apply false
+    alias(libs.plugins.firebase.crashlytics) apply false
     alias(libs.plugins.gradle.ktlint)
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -34,6 +34,11 @@ room = "2.8.4"
 # Lint & Formatting
 ktlint = "14.0.1"
 
+# Firebase
+firebaseBom = "34.9.0"
+googleServices = "4.4.4"
+firebaseCrashlyticsPlugin = "3.0.6"
+
 # Google Play Services
 ossLicensesPlugin = "0.10.10"
 playServicesOssLicenses = "17.4.0"
@@ -106,6 +111,10 @@ room-compiler = { group = "androidx.room", name = "room-compiler", version.ref =
 # Unit Test
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 
+# Firebase
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-crashlytics = { group = "com.google.firebase", name = "firebase-crashlytics" }
+
 # Google Play Services
 play-services-oss-licenses = { group = "com.google.android.gms", name = "play-services-oss-licenses", version.ref = "playServicesOssLicenses" }
 
@@ -125,6 +134,8 @@ hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 gradle-ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 oss-licenses = { id = "com.google.android.gms.oss-licenses-plugin", version.ref = "ossLicensesPlugin" }
+google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
+firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }
 
 # Custom Plugins
 chac-android-application = { id = "chac.android.application" }


### PR DESCRIPTION
## Summary
- Firebase Crashlytics SDK 연동 (BOM 34.9.0)
- Release 빌드에서 Timber 로그(INFO 이상)와 Exception을 Crashlytics로 전송하는 `CrashlyticsTree` 구현
- `google-services.json`을 `.gitignore`에 추가하여 민감 정보 보호

## Test plan
- [ ] Debug 빌드에서 기존 Timber.DebugTree 동작 확인
- [ ] Release 빌드에서 Crashlytics 대시보드에 크래시 리포트 수신 확인
- [ ] `Timber.e(exception, "message")` 호출 시 Crashlytics에 non-fatal 기록 확인

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)