### PR TITLE
[#71] 디자인 구현 보완 사항 2차

### DIFF
--- a/app/src/main/java/com/chac/AppNavigation.kt
+++ b/app/src/main/java/com/chac/AppNavigation.kt
@@ -6,8 +6,12 @@ import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -67,6 +71,7 @@ private fun ChacNavHost(
     Scaffold(
         modifier = Modifier.fillMaxSize(),
         containerColor = ChacColors.Background,
+        contentWindowInsets = WindowInsets.safeDrawing.only(WindowInsetsSides.Horizontal + WindowInsetsSides.Bottom),
     ) { innerPadding ->
         NavDisplay(
             backStack = backStack,

--- a/app/src/main/java/com/chac/MainActivity.kt
+++ b/app/src/main/java/com/chac/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.chac
 
+import android.graphics.Color as AndroidColor
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
@@ -17,7 +18,7 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         installSplashScreen()
         enableEdgeToEdge(
-            statusBarStyle = SystemBarStyle.dark(ChacColors.Background.toArgb()),
+            statusBarStyle = SystemBarStyle.dark(AndroidColor.TRANSPARENT),
             navigationBarStyle = SystemBarStyle.dark(ChacColors.Background.toArgb()),
         )
         setContent {

--- a/core/resources/src/main/res/drawable/im_album_save_success.xml
+++ b/core/resources/src/main/res/drawable/im_album_save_success.xml
@@ -1,19 +1,21 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="118dp"
-    android:height="88dp"
-    android:viewportWidth="118"
-    android:viewportHeight="88">
-  <path
-      android:pathData="M31.83,0C34.52,0 36.88,1.79 37.61,4.37L38.67,8.13C39.4,10.72 41.76,12.5 44.45,12.5H97.87C101.18,12.5 103.87,15.19 103.87,18.5V36.27C100.75,35.13 97.38,34.5 93.87,34.5C77.85,34.5 64.87,47.48 64.87,63.5C64.87,68.38 66.07,72.98 68.2,77.01L6,77C2.69,77 0,74.31 0,71V6C0,2.69 2.69,-0 6,0L31.83,0Z"
-      android:fillColor="#A284FF"/>
-  <path
-      android:pathData="M93.87,39.5L93.87,39.5A24,24 0,0 1,117.87 63.5L117.87,63.5A24,24 0,0 1,93.87 87.5L93.87,87.5A24,24 0,0 1,69.87 63.5L69.87,63.5A24,24 0,0 1,93.87 39.5z"
-      android:fillColor="#7346FF"/>
-  <path
-      android:pathData="M101.2,58L91.12,68.08L86.53,63.5"
-      android:strokeLineJoin="round"
-      android:strokeWidth="3"
-      android:fillColor="#00000000"
-      android:strokeColor="#F6F6F6"
-      android:strokeLineCap="round"/>
+    android:width="140dp"
+    android:height="100dp"
+    android:viewportWidth="140"
+    android:viewportHeight="100">
+    <path
+        android:pathData="M51.43,14C52.74,14 53.96,14.64 54.71,15.71L56.51,18.29C57.26,19.36 58.49,20 59.79,20H103C105.21,20 107,21.79 107,24V41.07C93.02,42.1 82,53.76 82,68C82,73.99 83.95,79.52 87.25,84H25C22.79,84 21,82.21 21,80V18C21,15.79 22.79,14 25,14H51.43Z"
+        android:fillColor="#14BCCC"
+        android:fillAlpha="0.6"/>
+    <path
+        android:pathData="M109.64,26C111.99,26 113.83,28.01 113.63,30.34L112.43,44.24C111.31,44.08 110.16,44 109,44C95.74,44 85,54.75 85,68C85,74.15 87.31,79.75 91.11,84H24.5C21.39,84 18.79,81.62 18.53,78.52L14.37,30.34C14.17,28.01 16.01,26 18.36,26H109.64Z"
+        android:fillColor="#14BCCC"
+        android:fillType="evenOdd"/>
+    <path
+        android:pathData="M109,68m-20,0a20,20 0,1 1,40 0a20,20 0,1 1,-40 0"
+        android:fillColor="#FC66FF"/>
+    <path
+        android:pathData="M113.44,61.44C114.03,60.85 114.97,60.85 115.56,61.44C116.15,62.02 116.15,62.97 115.56,63.56L111.12,68L115.56,72.44C116.15,73.02 116.15,73.97 115.56,74.56C114.97,75.15 114.03,75.15 113.44,74.56L109,70.12L104.56,74.56C103.97,75.15 103.03,75.15 102.44,74.56C101.85,73.97 101.85,73.02 102.44,72.44L106.88,68L102.44,63.56C101.85,62.97 101.85,62.02 102.44,61.44C103.03,60.85 103.97,60.85 104.56,61.44L109,65.88L113.44,61.44Z"
+        android:fillColor="#F6F6F6"
+        android:fillType="evenOdd"/>
 </vector>

--- a/core/resources/src/main/res/drawable/im_album_section_body_empty.xml
+++ b/core/resources/src/main/res/drawable/im_album_section_body_empty.xml
@@ -1,24 +1,21 @@
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
-    android:width="92dp"
-    android:height="68dp"
-    android:viewportWidth="92"
-    android:viewportHeight="68">
-  <path
-      android:pathData="M24.103,0.001C26.604,0.001 28.799,1.666 29.475,4.074L29.941,5.737C30.617,8.146 32.812,9.811 35.313,9.811H75.323C78.405,9.811 80.903,12.308 80.903,15.39V28.765C78.185,27.577 75.183,26.918 72.027,26.918C59.77,26.918 49.833,36.855 49.833,49.112C49.833,53.25 50.967,57.122 52.938,60.438L5.579,60.427C2.498,60.426 0,57.928 0,54.848V5.58C0,2.499 2.499,-0 5.58,0L24.103,0.001Z"
-      android:fillColor="#A284FF"/>
-  <path
-      android:pathData="M72.154,30.222L72.154,30.222A18.889,18.889 0,0 1,91.043 49.111L91.043,49.111A18.889,18.889 0,0 1,72.154 68L72.154,68A18.889,18.889 0,0 1,53.265 49.111L53.265,49.111A18.889,18.889 0,0 1,72.154 30.222z"
-      android:fillColor="#7346FF"/>
-  <path
-      android:pathData="M66.96,54.306L77.349,43.917"
-      android:strokeWidth="3.02222"
-      android:fillColor="#00000000"
-      android:strokeColor="#F6F6F6"
-      android:strokeLineCap="round"/>
-  <path
-      android:pathData="M77.349,54.305L66.96,43.917"
-      android:strokeWidth="3.02222"
-      android:fillColor="#00000000"
-      android:strokeColor="#F6F6F6"
-      android:strokeLineCap="round"/>
+    android:width="140dp"
+    android:height="100dp"
+    android:viewportWidth="140"
+    android:viewportHeight="100">
+    <path
+        android:pathData="M51.43,14C52.74,14 53.96,14.64 54.71,15.71L56.51,18.29C57.26,19.36 58.49,20 59.79,20H103C105.21,20 107,21.79 107,24V41.07C93.02,42.1 82,53.76 82,68C82,73.99 83.95,79.52 87.25,84H25C22.79,84 21,82.21 21,80V18C21,15.79 22.79,14 25,14H51.43Z"
+        android:fillColor="#14BCCC"
+        android:fillAlpha="0.6"/>
+    <path
+        android:pathData="M109.64,26C111.99,26 113.83,28.01 113.63,30.34L112.43,44.24C111.31,44.08 110.16,44 109,44C95.74,44 85,54.75 85,68C85,74.15 87.31,79.75 91.11,84H24.5C21.39,84 18.79,81.62 18.53,78.52L14.37,30.34C14.17,28.01 16.01,26 18.36,26H109.64Z"
+        android:fillColor="#14BCCC"
+        android:fillType="evenOdd"/>
+    <path
+        android:pathData="M109,68m-20,0a20,20 0,1 1,40 0a20,20 0,1 1,-40 0"
+        android:fillColor="#FC66FF"/>
+    <path
+        android:pathData="M113.44,61.44C114.03,60.85 114.97,60.85 115.56,61.44C116.15,62.02 116.15,62.97 115.56,63.56L111.12,68L115.56,72.44C116.15,73.02 116.15,73.97 115.56,74.56C114.97,75.15 114.03,75.15 113.44,74.56L109,70.12L104.56,74.56C103.97,75.15 103.03,75.15 102.44,74.56C101.85,73.97 101.85,73.02 102.44,72.44L106.88,68L102.44,63.56C101.85,62.97 101.85,62.02 102.44,61.44C103.03,60.85 103.97,60.85 104.56,61.44L109,65.88L113.44,61.44Z"
+        android:fillColor="#F6F6F6"
+        android:fillType="evenOdd"/>
 </vector>

--- a/feature/album/src/main/java/com/chac/feature/album/clustering/ClusteringScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/clustering/ClusteringScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
@@ -134,6 +135,7 @@ private fun ClusteringScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .statusBarsPadding()
             .background(ChacColors.Background)
             .padding(horizontal = 20.dp),
     ) {

--- a/feature/album/src/main/java/com/chac/feature/album/clustering/ClusteringScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/clustering/ClusteringScreen.kt
@@ -290,7 +290,7 @@ private fun EmptyState() {
                 modifier = Modifier.offset(x = 5.07.dp), // 시각적인 중앙값 보정
             )
 
-            Spacer(modifier = Modifier.height(31.dp))
+            Spacer(modifier = Modifier.height(20.dp))
 
             Text(
                 text = stringResource(R.string.clustering_empty_message),

--- a/feature/album/src/main/java/com/chac/feature/album/clustering/component/ClusterList.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/clustering/component/ClusterList.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -41,6 +42,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.Dp
@@ -277,12 +280,19 @@ private fun ClusterThumbnail(
                     color = ChacColors.Token00000070,
                     shape = CircleShape,
                 )
+                .defaultMinSize(minWidth = 27.dp, minHeight = 17.dp)
                 .padding(horizontal = 6.dp),
+            contentAlignment = Alignment.Center,
         ) {
             Text(
                 text = "+${formatCount(mediaCount)}",
-                style = ChacTextStyles.SubNumber,
                 color = ChacColors.TextBtn01,
+                maxLines = 1,
+                softWrap = false,
+                textAlign = TextAlign.Center,
+                style = ChacTextStyles.SubNumber.copy(
+                    platformStyle = PlatformTextStyle(includeFontPadding = false),
+                ),
             )
         }
     }

--- a/feature/album/src/main/java/com/chac/feature/album/gallery/GalleryScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/gallery/GalleryScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
@@ -201,6 +202,7 @@ private fun GalleryScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .statusBarsPadding()
                 .background(ChacColors.Background)
                 .padding(horizontal = 20.dp)
                 .padding(bottom = 20.dp),

--- a/feature/album/src/main/java/com/chac/feature/album/gallery/component/MediaPreviewScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/gallery/component/MediaPreviewScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.material3.CircularProgressIndicator
@@ -109,6 +110,7 @@ private fun MediaPreviewRouteScreen(
             Box(
                 modifier = Modifier
                     .fillMaxSize()
+                    .statusBarsPadding()
                     .background(ChacColors.Background),
                 contentAlignment = Alignment.Center,
             ) {
@@ -159,6 +161,7 @@ private fun MediaPreviewScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .statusBarsPadding()
             .background(ChacColors.Background),
     ) {
         Row(

--- a/feature/album/src/main/java/com/chac/feature/album/onboarding/OnboardingScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/onboarding/OnboardingScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
@@ -80,6 +81,7 @@ private fun OnboardingScreen(
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .statusBarsPadding()
                 .padding(horizontal = 20.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {

--- a/feature/album/src/main/java/com/chac/feature/album/onboarding/OnboardingScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/onboarding/OnboardingScreen.kt
@@ -65,13 +65,18 @@ private fun OnboardingScreen(
     val coroutineScope = rememberCoroutineScope()
     val isLastPage = pagerState.currentPage == ONBOARDING_PAGE_COUNT - 1
 
-    Box {
-        Image(
-            painter = painterResource(R.drawable.im_onboarding_bg),
-            contentDescription = null,
+    Box(modifier = Modifier.fillMaxSize()) {
+        HorizontalPager(
+            state = pagerState,
             modifier = Modifier.fillMaxSize(),
-            contentScale = ContentScale.Crop,
-        )
+        ) { page ->
+            if (page == 0) {
+                OnboardingFirstPage(modifier = Modifier.fillMaxSize())
+            } else {
+                OnboardingPage(page = page, modifier = Modifier.fillMaxSize())
+            }
+        }
+
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -88,20 +93,7 @@ private fun OnboardingScreen(
                     .clickable(onClick = onCompleted),
             )
 
-            HorizontalPager(
-                state = pagerState,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
-            ) { page ->
-                if (page == 0) {
-                    OnboardingFirstPage()
-                } else {
-                    OnboardingPage(page = page)
-                }
-            }
-
-            Spacer(modifier = Modifier.height(32.dp))
+            Spacer(modifier = Modifier.weight(1f))
 
             PageIndicator(
                 currentPage = pagerState.currentPage,
@@ -201,31 +193,40 @@ private fun OnboardingPage(
 private fun OnboardingFirstPage(
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier.fillMaxSize(),
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center,
-    ) {
+    Box(modifier = modifier.fillMaxSize()) {
         Image(
-            painter = painterResource(R.drawable.im_onboarding_logo),
+            painter = painterResource(R.drawable.im_onboarding_bg),
             contentDescription = null,
+            modifier = Modifier.fillMaxSize(),
+            contentScale = ContentScale.Crop,
         )
 
-        Spacer(modifier = Modifier.height(26.dp))
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Image(
+                painter = painterResource(R.drawable.im_onboarding_logo),
+                contentDescription = null,
+            )
 
-        Image(
-            painter = painterResource(R.drawable.im_onboarding_watermark),
-            contentDescription = null,
-        )
+            Spacer(modifier = Modifier.height(26.dp))
 
-        Spacer(modifier = Modifier.height(20.dp))
+            Image(
+                painter = painterResource(R.drawable.im_onboarding_watermark),
+                contentDescription = null,
+            )
 
-        Text(
-            text = stringResource(R.string.onboarding_page0_title),
-            style = ChacTextStyles.Headline01,
-            color = ChacColors.Text01,
-            textAlign = TextAlign.Center,
-        )
+            Spacer(modifier = Modifier.height(20.dp))
+
+            Text(
+                text = stringResource(R.string.onboarding_page0_title),
+                style = ChacTextStyles.Headline01,
+                color = ChacColors.Text01,
+                textAlign = TextAlign.Center,
+            )
+        }
     }
 }
 

--- a/feature/album/src/main/java/com/chac/feature/album/onboarding/OnboardingScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/onboarding/OnboardingScreen.kt
@@ -1,5 +1,9 @@
 package com.chac.feature.album.onboarding
 
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -246,20 +250,26 @@ private fun PageIndicator(
 ) {
     Row(
         modifier = modifier,
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
+        horizontalArrangement = Arrangement.spacedBy(6.dp),
     ) {
         repeat(pageCount) { index ->
+            val isSelected = index == currentPage
+            val indicatorWidth = animateDpAsState(
+                targetValue = if (isSelected) 16.dp else 8.dp,
+                animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing),
+                label = "pageIndicatorWidth",
+            )
+            val indicatorColor = animateColorAsState(
+                targetValue = if (isSelected) ChacColors.Primary else ChacColors.TextBtn01.copy(alpha = 0.1f),
+                animationSpec = tween(durationMillis = 250, easing = FastOutSlowInEasing),
+                label = "pageIndicatorColor",
+            )
+
             Box(
                 modifier = Modifier
-                    .size(8.dp)
+                    .size(width = indicatorWidth.value, height = 8.dp)
                     .clip(CircleShape)
-                    .background(
-                        if (index == currentPage) {
-                            ChacColors.Primary
-                        } else {
-                            ChacColors.Text04Caption.copy(alpha = 0.3f)
-                        },
-                    ),
+                    .background(indicatorColor.value),
             )
         }
     }

--- a/feature/album/src/main/java/com/chac/feature/album/save/AlbumTitleEditScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/save/AlbumTitleEditScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -145,6 +146,7 @@ fun AlbumTitleEditScreen(
         modifier = modifier
             .fillMaxSize()
             .background(ChacColors.Background)
+            .statusBarsPadding()
             .windowInsetsPadding(WindowInsets.ime.exclude(WindowInsets.navigationBars))
             .padding(bottom = 20.dp),
     ) {

--- a/feature/album/src/main/java/com/chac/feature/album/save/AlbumTitleEditViewModel.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/save/AlbumTitleEditViewModel.kt
@@ -1,5 +1,6 @@
 package com.chac.feature.album.save
 
+import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.input.TextFieldValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -111,7 +112,10 @@ class AlbumTitleEditViewModel @Inject constructor(
 
                 _uiState.value = AlbumTitleEditUiState(
                     isInitialized = true,
-                    title = TextFieldValue(""),
+                    title = TextFieldValue(
+                        text = defaultTitle,
+                        selection = TextRange(defaultTitle.length),
+                    ),
                     placeholder = defaultTitle,
                     selectedCount = mediaList.size,
                     selectedUriStrings = mediaList.map { it.uriString },

--- a/feature/album/src/main/java/com/chac/feature/album/save/SaveCompletedScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/save/SaveCompletedScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -75,6 +76,7 @@ private fun SaveCompletedScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .statusBarsPadding()
             .background(color = ChacColors.Background)
             .padding(horizontal = 20.dp)
             .padding(bottom = 20.dp),

--- a/feature/album/src/main/java/com/chac/feature/album/save/SaveCompletedScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/save/SaveCompletedScreen.kt
@@ -123,7 +123,7 @@ private fun SaveCompletedScreen(
                     modifier = Modifier.offset(x = 7.dp), // 시각적인 중심점 보정
                 )
 
-                Spacer(modifier = Modifier.height(26.dp))
+                Spacer(modifier = Modifier.height(20.dp))
 
                 Text(
                     text = stringResource(R.string.save_completed_title),

--- a/feature/album/src/main/java/com/chac/feature/album/settings/SettingsScreen.kt
+++ b/feature/album/src/main/java/com/chac/feature/album/settings/SettingsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -76,6 +77,7 @@ private fun SettingsScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .statusBarsPadding()
             .background(ChacColors.Background)
             .padding(horizontal = 20.dp),
     ) {


### PR DESCRIPTION
## 이 PR의 주요 목적 요약
현재 구현된 UI 에서 디자인과의 차이점을 보완하고 추가 사항을 대응합니다.

## 구현된 주요 기능/변경사항 (bullet points)
- `ClusteringScreen` 목록 카드의 인디케이터의 padding 결함 대응
<img width="320" alt="Image" src="https://github.com/user-attachments/assets/9db664b9-03b3-4eeb-987c-68c7a15afa3f" />

- 앨범명 변경 페이지 진입시 클러스터의 타이틀이 선입력 되어진 상태로 진입되도록 수정 [[Figma 링크](https://www.figma.com/design/ffAKlZ76yWTYjgscfwtaqQ/-%EB%84%A5%EC%8A%A4%ED%84%B0%EC%A6%88--%EC%B0%A9%EC%B0%A9_%EB%94%94%EC%9E%90%EC%9D%B8?node-id=1315-6133&t=s8VxnPSJcrQXyEWa-4)]
- `ClusteringScreen`의 Empty 상태 일러스트 이미지 변경 [[Figma 링크](https://www.figma.com/design/ffAKlZ76yWTYjgscfwtaqQ/-%EB%84%A5%EC%8A%A4%ED%84%B0%EC%A6%88--%EC%B0%A9%EC%B0%A9_%EB%94%94%EC%9E%90%EC%9D%B8?node-id=354-1395&t=s8VxnPSJcrQXyEWa-4)]
- 저장 완료 화면의 일러스트 이미지 변경 [[Figma 링크](https://www.figma.com/design/ffAKlZ76yWTYjgscfwtaqQ/-%EB%84%A5%EC%8A%A4%ED%84%B0%EC%A6%88--%EC%B0%A9%EC%B0%A9_%EB%94%94%EC%9E%90%EC%9D%B8?node-id=306-2857&t=s8VxnPSJcrQXyEWa-4)]
- 온보딩 화면 인디케이터의 선택된 인덱스의 `width` 수정
<img width="320" alt="Image" src="https://github.com/user-attachments/assets/3653c850-d714-4bba-9db9-57ed4ac2d93f" />

- 온보딩 화면 Background를 SystemBar 영역까지 확장
- 온보딩 화면 Horizontal Padding이 컨텐츠 영역에 영향을 주지 않도록 수정
<img width="320" alt="Image" src="https://github.com/user-attachments/assets/fa4385e2-c779-42cb-a25c-30718c750f67" />

## 추가 참고사항이나 검토 포인트
- https://github.com/Nexters/Chac-Android/pull/77 에서 이어지는 작업 입니다.
